### PR TITLE
Enable build with static library for zck

### DIFF
--- a/src/lib/meson.build
+++ b/src/lib/meson.build
@@ -6,7 +6,7 @@ subdir('hash')
 subdir('index')
 subdir('dl')
 lib_sources += files('zck.c', 'header.c', 'io.c', 'log.c', 'compint.c', 'error.c')
-zcklib = shared_library('zck',
+zcklib = library('zck',
                         lib_sources,
                         include_directories: inc,
                         dependencies: [zstd_dep, openssl_dep],


### PR DESCRIPTION
Very small change in Meson config to allow zck to build
with a static library instead of just a dynamic one.

To use, run "meson --default-library=static build"

The resulting binaries should now be statically linked
with zck (resuilting in fewer dependencies).