### PR TITLE
Open files with permissions 0666 and let umask(2) do its job.

### DIFF
--- a/src/unzck.c
+++ b/src/unzck.c
@@ -139,7 +139,7 @@ int main (int argc, char *argv[]) {
 
     int dst_fd = STDOUT_FILENO;
     if(!arguments.stdout) {
-        dst_fd = open(out_name, O_TRUNC | O_WRONLY | O_CREAT, 0644);
+        dst_fd = open(out_name, O_TRUNC | O_WRONLY | O_CREAT, 0666);
         if(dst_fd < 0) {
             dprintf(STDERR_FILENO, "Unable to open %s", out_name);
             perror("");

--- a/src/zck.c
+++ b/src/zck.c
@@ -179,7 +179,7 @@ int main (int argc, char *argv[]) {
         close(dict_fd);
     }
 
-    int dst_fd = open(out_name, O_TRUNC | O_WRONLY | O_CREAT, 0644);
+    int dst_fd = open(out_name, O_TRUNC | O_WRONLY | O_CREAT, 0666);
     if(dst_fd < 0) {
         dprintf(STDERR_FILENO, "Unable to open %s", out_name);
         perror("");

--- a/src/zck_dl.c
+++ b/src/zck_dl.c
@@ -314,7 +314,7 @@ int main (int argc, char *argv[]) {
     }
 
     char *outname = basename(arguments.args[0]);
-    int dst_fd = open(outname, O_RDWR | O_CREAT, 0644);
+    int dst_fd = open(outname, O_RDWR | O_CREAT, 0666);
     if(dst_fd < 0) {
         dprintf(STDERR_FILENO, "Unable to open %s: %s\n", outname,
                 strerror(errno));

--- a/src/zck_gen_zdict.c
+++ b/src/zck_gen_zdict.c
@@ -224,7 +224,7 @@ int main (int argc, char *argv[]) {
         assert(dict_block);
         snprintf(dict_block, strlen(dir) + strlen(out_name) + 12, "%s/%s.%li",
                  dir, out_name, zck_get_chunk_number(idx));
-        int dst_fd = open(dict_block, O_TRUNC | O_WRONLY | O_CREAT, 0644);
+        int dst_fd = open(dict_block, O_TRUNC | O_WRONLY | O_CREAT, 0666);
         if(dst_fd < 0) {
             dprintf(STDERR_FILENO, "Unable to open %s", dict_block);
             perror("");

--- a/test/copy_chunks.c
+++ b/test/copy_chunks.c
@@ -49,7 +49,7 @@ int main (int argc, char *argv[]) {
         perror("Unable to open LICENSE.header.new.nodict.fodt.zck for reading");
         exit(1);
     }
-    int tgt = open(base_name, O_RDWR | O_CREAT, 0644);
+    int tgt = open(base_name, O_RDWR | O_CREAT, 0666);
     if(tgt < 0) {
         perror("Unable to open LICENSE.header.new.nodict.fodt.zck for writing");
         exit(1);


### PR DESCRIPTION
When creating files, zchunk did not obey the users's umask(2) setting.