### PR TITLE
Add uncompressed source flag to zchunk_format.txt

### DIFF
--- a/zchunk_format.txt
+++ b/zchunk_format.txt
@@ -1,3 +1,7 @@
+NOTE: Any flags marked EXPERIMENTAL are still in development and the format, as
+      it applies to those flags, is still in flux.  It is strongly recommended
+      that no public zchunk files be created using EXPERIMENTAL flags
+
 A zchunk file contains two parts, the header and the body.  The header consists
 of four parts:
  * The lead: Everything necessary to validate the header
@@ -68,6 +72,7 @@ Flags
  Current flags are:
   bit 0: File has data streams
   bit 1: File has optional elements
+  bit 2: EXPERIMENTAL: File may be applied against an uncompressed source
 
 Compression type
  This is an integer containing the type of compression used to compress dict and
@@ -116,13 +121,14 @@ The index:
 +===============================+
 
 (Chunk stream will only exist if flag 0 is set to 1)
-[+===================+================+===================+
-[| Chunk stream (ci) | Chunk checksum | Chunk length (ci) |
-[+===================+================+===================+
+EXPERIMENTAL: (Uncompressed chunk checksum will only exist if flag 2 is set to 1)
+[+===================+================+=============================+
+[| Chunk stream (ci) | Chunk checksum | Uncompressed chunk checksum |
+[+===================+================+=============================+
 
-+==========================+]
-| Uncompressed length (ci) |] ...
-+==========================+]
++===================+==========================+]
+| Chunk length (ci) | Uncompressed length (ci) |] ...
++===================+==========================+]
 
 Index size
  This is an integer containing the size of the index.
@@ -167,6 +173,12 @@ Chunk stream
 Chunk checksum
  This is the checksum of the compressed chunk, used to detect whether any two
  chunks are identical.
+
+EXPERIMENTAL: NOTE: Uncompressed chunk checksum will only exist if flag 2 is set
+                    to 1
+Uncompressed chunk checksum
+ This is the checksum of the uncompressed chunk, used to detect whether a chunk
+ from an uncompressed source is identical to the compressed chunk
 
 Chunk length
  This is an integer containing the length of the chunk.

--- a/zchunk_format.txt
+++ b/zchunk_format.txt
@@ -9,13 +9,16 @@ of four parts:
  * The index: Details about each chunk
  * The signatures: Signatures used to sign the zchunk file
 
-Definitions:
+Definitions and document conventions:
 (ci)
  Compressed (unsigned) integer - An variable length little endian integer where
  the first seven bits of the number are stored in the first byte, followed by
  the next seven bits in the next byte, and so on.  The top bit of all bytes
  except the final byte must be zero, and the top bit of the final byte must be
  one, indicating the end of the number.
+
+[#]
+ Section is only used if flag # is set.
 
 The lead:
 +-+-+-+-+-+====================+==================+=================+
@@ -46,18 +49,17 @@ The preface:
 | Data checksum | Flags (ci) | Compression type (ci ) |
 +===============+============+========================+
 
-(Optional elements will only be set if flag 1 is set to 1)
-+=============================+
-| Optional element count (ci) |
-+=============================+
++=================================+
+| Optional element count (ci) [1] |
++=================================+
 
-[+==========================+=================================+
-[| Optional element id (ci) | Optional element data size (ci) |
-[+==========================+=================================+
+[+==============================+=====================================+
+[| Optional element id (ci) [1] | Optional element data size (ci) [1] |
+[+==============================+=====================================+
 
-+=======================+]
-| Optional element data |] ...
-+=======================+]
++===========================+]
+| Optional element data [1] |] ...
++===========================+]
 
 Data checksum
  This is the checksum of everything after the header, including the compressed
@@ -112,19 +114,17 @@ The index:
 +=================+==========================+==================+
 
 (Dict stream will only exist if flag 0 is set to 1)
-+==================+===============+==================+
-| Dict stream (ci) | Dict checksum | Dict length (ci) |
-+==================+===============+==================+
++======================+===============+==================+
+| Dict stream (ci) [0] | Dict checksum | Dict length (ci) |
++======================+===============+==================+
 
 +===============================+
 | Uncompressed dict length (ci) |
 +===============================+
 
-(Chunk stream will only exist if flag 0 is set to 1)
-EXPERIMENTAL: (Uncompressed chunk checksum will only exist if flag 2 is set to 1)
-[+===================+================+=============================+
-[| Chunk stream (ci) | Chunk checksum | Uncompressed chunk checksum |
-[+===================+================+=============================+
+[+=======================+================+=================================+
+[| Chunk stream (ci) [0] | Chunk checksum | Uncompressed chunk checksum [2] |
+[+=======================+================+=================================+
 
 +===================+==========================+]
 | Chunk length (ci) | Uncompressed length (ci) |] ...


### PR DESCRIPTION
This flag indicates that the zchunk file will contain uncompressed chunk checksums as well as the normal compressed chunk checksums so a zchunk file can be downloaded against an uncompressed source, though it will probably need to be decompressed on the fly to make an uncompressed target.