### PR TITLE
Add manual page stubs for the command-line utilities.

### DIFF
--- a/doc/unzck.1
+++ b/doc/unzck.1
@@ -1,0 +1,103 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt UNZCK 1
+.Os
+.Sh NAME
+.Nm unzck
+.Nd decompress a file in the zchunk format
+.Sh SYNOPSIS
+.Nm
+.Op Fl c | Fl -stdout
+.Op Fl -dict
+.Op Fl v | Fl -verbose
+.Ar file
+.Nm
+.Fl ? | Fl -help
+.Nm
+.Fl -usage
+.Nm
+.Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility extracts the original file from a zchunk-compressed one.
+.Pp
+.Em NOTE:
+The
+.Nm
+utility will place the new file without the
+.Pa .zck
+extension in the
+.Em current
+working directory, not in the directory where the original file resides.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl c , Fl -stdout
+Extract the data to the standard output stream, do not write it to a file.
+.It Fl -dict
+Only extract the zstd compression dictionary.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Create (in the current directory) an uncompressed
+.Pa words
+file from a compressed one:
+.Pp
+.Dl unzck /mnt/xfer/words.zck
+.Pp
+Do not create the
+.Pa words
+file, but send the contents to the standard output stream:
+.Pp
+.Dl unzck -c /mnt/xfer/words.zck
+.Pp
+.Sh SEE ALSO
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1 ,
+.Xr zckdl 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/doc/zck.1
+++ b/doc/zck.1
@@ -1,0 +1,110 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt ZCK 1
+.Os
+.Sh NAME
+.Nm zck
+.Nd compress a file using the zchunk format
+.Sh SYNOPSIS
+.Nm
+.Op Fl D Ar file | Fl -dict Ns = Ns Ar file
+.Op Fl m Ar chunk | Fl -manual Ns = Ns Ar chunk
+.Op Fl o Ar file | Fl -output Ns = Ns Ar file
+.Op Fl s Ar string | Fl -split Ns = Ns Ar string
+.Op Fl v | Fl -verbose
+.Ar file
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility creates a new zchunk file from the data in the specified input file.
+.Pp
+.Em NOTE:
+If no output file is specified using the
+.Fl o
+option, the
+.Nm
+utility will place the new file with the
+.Pa .zck
+extension in the
+.Em current
+working directory, not in the directory where the original file resides.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl D , Fl -dict
+Set the zstd compression dictionary to the specified file.
+.It Fl m , Fl -manual
+Do not do any automatic chunking (implies
+.Fl s ) .
+.It Fl o , Fl -output
+Output to the specified file.
+.It Fl s , Fl -split
+Split chunks at the beginning of the specified string.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Create (in the current directory) a zchunk-compressed
+.Pa words.zck
+file from a dictionary:
+.Pp
+.Dl zck /usr/share/dict/words
+.Pp
+The same, but specify an output file:
+.Pp
+.Dl zck -o /tmp/words.txt.zck /usr/share/dict/words
+.Pp
+Generate a zchunk file with chunks separated on HTML sections:
+.Pp
+.Dl zck -s '<h2>' doc.html
+.Pp
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1 ,
+.Xr zckdl 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/doc/zck_delta_size.1
+++ b/doc/zck_delta_size.1
@@ -1,0 +1,89 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt ZCK_DELTA_SIZE 1
+.Os
+.Sh NAME
+.Nm zck_delta_size
+.Nd calculate the differences between two zchunk files
+.Sh SYNOPSIS
+.Nm
+.Op Fl v | Fl -verbose
+.Ar file1
+.Ar file2
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility examines two zchunk compressed files and determines how similar
+they are: how many chunks are the same between the files, so that tools
+like e.g.
+.Xr rsync 1
+or
+.Xr zckdl 1
+could only transfer the small parts that differ instead of the full files.
+This is especially useful for structured files that have been compressed
+using the
+.Xr zck 1
+tool's
+.Fl s Po Fl -split Pc
+option.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Examine two zchunk files:
+.Pp
+.Dl zck_delta_size doc1.txt.zck doc2.txt.zck
+.Pp
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1 ,
+.Xr zckdl 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/doc/zck_gen_zdict.1
+++ b/doc/zck_gen_zdict.1
@@ -1,0 +1,92 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt ZCK_GEN_ZDICT 1
+.Os
+.Sh NAME
+.Nm zck_gen_zdict
+.Nd extract a dictionary and optionally the separate chunks from a zdict file
+.Sh SYNOPSIS
+.Nm
+.Op Fl d Ar directory | Fl -dir Ns = Ns Ar directory
+.Op Fl v | Fl -verbose
+.Ar file
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility reads the specified zchunk file, extracts the dictionary used
+during the compression, and optionally uncompresses the individual chunks
+into the specified directory.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl d , Fl -dir
+In addition to extracting the dictionary, uncompress the individual chunks
+as sequential files into the specified directory.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Extract a zchunk file's dictionary into the
+.Pa words.txt.zdict
+file:
+.Pp
+.Dl zck_gen_zdict words.txt.zck
+.Pp
+Extract the dictionary into
+.Pa words.txt.zdict
+and also the chunks into the
+.Pa chunks/
+directory:
+.Pp
+.Dl zck_gen_zdict -d chunks/ words.txt.zck
+.Pp
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_read_header 1 ,
+.Xr zckdl 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/doc/zck_read_header.1
+++ b/doc/zck_read_header.1
@@ -1,0 +1,87 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt ZCK_READ_HEADER 1
+.Os
+.Sh NAME
+.Nm zck_read_header
+.Nd display information from the header of a zchunk file
+.Sh SYNOPSIS
+.Nm
+.Op Fl c | Fl -show-chunks
+.Op Fl f | Fl -verify
+.Op Fl q | Fl -quiet
+.Op Fl v | Fl -verbose
+.Ar file
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility reads a zchunk file's header and displays some of the information
+recorded there.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl c , Fl -show-chunks
+Display information about the individual chunks, too.
+.It Fl f , Fl -verify
+Instead of only reading the zchunk file's header, read the whole file and
+verify its integrity.
+.It Fl q , Fl -quiet
+Quiet operation; only display error messages.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Examine a zchunk file's header:
+.Pp
+.Dl zck_delta_size doc.txt.zck
+.Pp
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zckdl 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/doc/zckdl.1
+++ b/doc/zckdl.1
@@ -1,0 +1,90 @@
+.\" Copyright (c) 2020  Peter Pentchev <roam@ringlet.net>
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\"  1. Redistributions of source code must retain the above copyright notice,
+.\"     this list of conditions and the following disclaimer.
+.\"
+.\"  2. Redistributions in binary form must reproduce the above copyright notice,
+.\"     this list of conditions and the following disclaimer in the documentation
+.\"     and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd May 31, 2020
+.Dt ZCKDL 1
+.Os
+.Sh NAME
+.Nm zckdl
+.Nd download a zchunk file
+.Sh SYNOPSIS
+.Nm
+.Op Fl -fail-no-ranges
+.Op Fl q | Fl -quiet
+.Op Fl s Ar file | Fl -source Ns = Ns Ar file
+.Op Fl v | Fl -verbose
+.Ar url
+.Nm
+.Fl ? | Fl -help | Fl -usage | Fl -version
+.Sh DESCRIPTION
+The
+.Nm
+utility attempts to download a zchunk file in an optimized way,
+taking into consideration the chunked structure.
+.Pp
+The
+.Nm
+utility accepts the following optional arguments:
+.Pp
+.Bl -tag -width indent
+.It Fl -fail-no-ranges
+If the server does not support ranges, fail instead of downloading
+the whole file.
+.It Fl q | Fl -quiet
+Quiet operation; only display warning and error messages.
+If specified twice, only display error messages.
+.It Fl s | Fl -source
+Specify the file to use as a source with the premise that most of
+the chunks in the downloaded file will be the same.
+.It Fl v , Fl -verbose
+Verbose operation; display some diagnostic output.
+.It Fl ? , Fl -help
+Display program usage information and exit.
+.It Fl -usage
+Display brief program usage information and exit.
+.It Fl -version
+Display program version information and exit.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Sh EXAMPLES
+Download a zchunk file that is hopefully not much different from
+the previous version:
+.Pp
+.Dl zckdl -s doc1.txt.zck https://example.com/doc2.txt.zck
+.Pp
+.Sh SEE ALSO
+.Xr unzck 1 ,
+.Xr zck 1 ,
+.Xr zck_delta_size 1 ,
+.Xr zck_gen_zdict 1 ,
+.Xr zck_read_header 1
+.Sh AUTHOR
+The
+.Nm
+utility was written by
+.An Jonathan Dieter Aq jdieter@gmail.com .
+This manual page stub was written by
+.An Peter Pentchev Aq roam@ringlet.net .

--- a/meson.build
+++ b/meson.build
@@ -51,3 +51,12 @@ pkg_mod.generate(libraries : zcklib,
                  name : 'libzck',
                  filebase : 'zck',
                  description : 'A library for generating easy-to-delta files.')
+
+install_man([
+  'doc/unzck.1',
+  'doc/zck.1',
+  'doc/zck_delta_size.1',
+  'doc/zck_gen_zdict.1',
+  'doc/zck_read_header.1',
+  'doc/zckdl.1',
+])


### PR DESCRIPTION
Hi,

What do you think about these manual page stubs? I know that they are very brief and that they currently do not really contain much more information than the usage messages themselves. However, in some cases (and with some old-fashioned people such as myself or the ones setting the Debian project policies :)) even a brief manual page is preferable to none.

If there should be any concern as to keeping the manual pages up-to-date with the changing source, I could tentatively make a commitment to taking care of this in the future. I might also be persuaded to fill out these stubs a bit :)

Thanks in advance, and keep up the great work!

G'luck,
Peter