### PR TITLE
macOS: Use correct endian.h & use argp-standalone

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ endif
 
 curl_dep = dependency('libcurl')
 
-if build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); }; void main() {}')
+if build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); }; void main() {}')
     argplib = cc.find_library('argp')
 else
     argplib = dependency('', required : false)

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #ifdef FREEBSD
 #include <sys/endian.h>
+#elif __APPLE__
+#include <machine/endian.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
As mentioned in #24 there are the 2 problems with compiling on macOS which this PR resolves:
1. <endian.h> is <machine/endian.h> on MacOS
2. argp-standalone should be searched for on MacOS



Tests pass on macOS 10.15.
In this specific snippet, my libraries are installed in non-standard locations.
```
oooo@oooos-MacBook-Pro zchunk4 % export C_INCLUDE_PATH=/nix/store/zgkjdw988darkzkyy198zfc71d4ck1n0-argp-standalone-1.3/include:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/include
oooo@oooos-MacBook-Pro zchunk4 % export PKG_CONFIG_PATH=/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig
oooo@oooos-MacBook-Pro zchunk4 % export LIBRARY_PATH=/nix/store/zgkjdw988darkzkyy198zfc71d4ck1n0-argp-standalone-1.3/lib:/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib
oooo@oooos-MacBook-Pro zchunk4 % meson build
Using 'PKG_CONFIG_PATH' from environment with value: '/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig'
Using 'PKG_CONFIG_PATH' from environment with value: '/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig'
The Meson build system
Version: 0.56.0
Source dir: /Volumes/home/fcorp/z chunk/zchunk4
Build dir: /Volumes/home/fcorp/z chunk/zchunk4/build
Build type: native build
Project name: zck
Project version: 1.1.8
C compiler for the host machine: cc (clang 12.0.0 "Apple clang version 12.0.0 (clang-1200.0.32.28)")
C linker for the host machine: cc ld64 609.8
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wunused-result: YES 
Found pkg-config: /Users/oooo/.nix-profile/bin/pkg-config (0.29.2)
Using 'PKG_CONFIG_PATH' from environment with value: '/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig'
Run-time dependency libzstd found: YES 1.4.5
Using 'PKG_CONFIG_PATH' from environment with value: '/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig'
Run-time dependency libcurl found: YES 7.74.0
Library argp found: YES
Using 'PKG_CONFIG_PATH' from environment with value: '/nix/store/m95ip2v1f5y339a5clma03ia6lxhg4nf-curl-7.74.0-dev/lib/pkgconfig:/nix/store/rk45fz45anwv8xmhzkzdbgbila92lrh1-zstd-1.4.5-dev/lib/pkgconfig:/nix/store/r7glhc06wpn3bvsyd7aaw0b1nlf5im7n-openssl-1.1.1i-dev/lib/pkgconfig'
Run-time dependency openssl found: YES 1.1.1i
Configuring zck.h using configuration
Build targets in project: 16

Found ninja-1.10.2 at /Users/oooo/.nix-profile/bin/ninja
oooo@oooos-MacBook-Pro zchunk4 % cd build 
oooo@oooos-MacBook-Pro build % ninja
[31/178] Linking target src/lib/libzck.1.dylib
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[67/178] Linking target test/empty
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[84/178] Linking target test/optelems
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[107/178] Linking target test/copy_chunks
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[126/178] Linking target test/invalid_input_checksum
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[145/178] Linking target test/read_single_chunk
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[168/178] Linking target test/read_single_comp_chunk
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[178/178] Linking target test/shacheck
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
oooo@oooos-MacBook-Pro build % ninja test
[1/9] Linking target src/lib/libzck.1.dylib
ld: warning: directory not found for option '-L/nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5//nix/store/sps7z74r4r31y962zdb2n4bk4if94qfq-zstd-1.4.5/lib'
[2/3] Running all tests.
 1/26 create and validate empty zchunk file  OK             0.14s
 2/26 check version info in zck              OK             0.29s
 3/26 check version info in unzck            OK             0.29s
 4/26 check version info in zckdl            OK             0.24s
 5/26 check version info in zck_read_header  OK             0.31s
 6/26 check version info in zck_delta_size   OK             0.25s
 7/26 check opening file with optional flags OK             0.20s
 8/26 checksum with non-hex character        OK             0.15s
 9/26 read single chunk                      OK             0.20s
10/26 read single compressed chunk           OK             0.14s
11/26 check verbosity in unzck               OK             0.19s
12/26 check verbosity in zck                 OK             0.14s
13/26 check verbosity in zckdl               EXPECTEDFAIL   0.56s
14/26 check verbosity in zck_read_header     OK             0.24s
15/26 check verbosity in zck_delta_size      OK             0.30s
16/26 copy chunks from source                OK             0.19s
17/26 decompress auto-chunked file - nocomp  OK             0.51s
18/26 decompress auto-chunked file - no dict OK             0.46s
19/26 decompress auto-chunked file - dict    OK             0.51s
20/26 decompress manual file - no dict       OK             0.52s
21/26 decompress manual file - dict          OK             0.66s
22/26 decompress dict from auto-chunked file OK             0.55s
23/26 compress auto-chunked file - no dict   OK             0.52s
24/26 compress auto-chunked file - dict      OK             0.38s
25/26 compress manual file - no dict         OK             0.42s
26/26 compress manual file - dict            OK             0.83s


Ok:                 25  
Expected Fail:      1   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /Volumes/home/fcorp/z chunk/zchunk4/build/meson-logs/testlog.txt
oooo@oooos-MacBook-Pro build % 

```