### PR TITLE
Fix build on cygwin

### DIFF
--- a/src/zck_gen_zdict.c
+++ b/src/zck_gen_zdict.c
@@ -42,6 +42,10 @@
 #include <argp.h>
 #include <zck.h>
 
+#if defined(stdout)
+#undef stdout
+#endif
+
 #include "util_common.h"
 
 static char doc[] = "zck_gen_zdict - Generate a zdict for a zchunk file";


### PR DESCRIPTION
Fix build on cygwin ( #42 )

```
$ ninja test
[0/1] /usr/bin/meson test --no-rebuild --print-errorlogs
 1/30 create and validate empty zchunk file                               OK              0.16s
 2/30 check version info in zck                                           OK              0.67s
 3/30 check version info in unzck                                         OK              1.23s
 4/30 check version info in zckdl                                         OK              1.51s
 5/30 check version info in zck_read_header                               OK              1.04s
 6/30 check version info in zck_delta_size                                OK              1.60s
 7/30 check opening file with optional flags                              OK              1.47s
 8/30 checksum with non-hex character                                     OK              0.92s
 9/30 read single chunk                                                   OK              1.01s
10/30 read single compressed chunk                                        OK              0.55s
11/30 check verbosity in unzck                                            OK              0.94s
12/30 check verbosity in zck                                              OK              0.47s
13/30 check verbosity in zckdl                                            EXPECTEDFAIL    0.78s   exit status 10
14/30 check verbosity in zck_read_header                                  OK              0.54s
15/30 check verbosity in zck_delta_size                                   OK              0.84s
16/30 copy chunks from source                                             OK              0.77s
17/30 decompress previously generated auto-chunked file - nocomp          OK              0.86s
18/30 decompress previously generated auto-chunked file - no dict         OK              1.10s
19/30 decompress previously generated auto-chunked file - dict            OK              1.15s
20/30 decompress previously generated manual file - no dict               OK              2.90s
21/30 decompress dict from previously generated auto-chunked file         OK              0.54s
22/30 decompress previously generated manual file - dict                  OK              3.05s
23/30 compress auto-chunked file - no dict                                OK              0.93s
24/30 decompress auto-chunked file - no dict                              OK              0.60s
25/30 compress auto-chunked file - dict                                   OK              0.74s
26/30 decompress auto-chunked file - dict                                 OK              0.55s
27/30 compress manual file - no dict                                      OK              0.57s
28/30 decompress manual file - no dict                                    OK              1.32s
29/30 compress manual file - dict                                         OK              0.79s
30/30 decompress manual file - dict                                       OK              1.20s


Ok:                 29
Expected Fail:      1
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

Full log written to /cygdrive/e/zchunk/build/meson-logs/testlog.txt
```