### PR TITLE
Introduce checksum for uncompressed data in the header

### DIFF
--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -26,6 +26,7 @@ typedef enum zck_ioption {
     ZCK_HASH_CHUNK_TYPE,        /* Set chunk hash type using zck_hash */
     ZCK_VAL_HEADER_HASH_TYPE,   /* Set what the header hash type *should* be */
     ZCK_VAL_HEADER_LENGTH,      /* Set what the header length *should* be */
+    ZCK_UNCOMP_HEADER,          /* Header should contain uncompressed size, too */
     ZCK_COMP_TYPE = 100,        /* Set compression type using zck_comp */
     ZCK_MANUAL_CHUNK,           /* Disable auto-chunking */
     ZCK_CHUNK_MIN,              /* Minimum chunk size when manual chunking */
@@ -262,6 +263,9 @@ char *zck_get_chunk_digest(zckChunk *item)
     __attribute__ ((warn_unused_result));
 /* Get digest size of chunk hash type */
 ssize_t zck_get_chunk_digest_size(zckCtx *zck)
+    __attribute__ ((warn_unused_result));
+/* Get uncompressed chunk digest */
+char *zck_get_chunk_digest_uncompressed(zckChunk *item)
     __attribute__ ((warn_unused_result));
 /* Get chunk data */
 ssize_t zck_get_chunk_data(zckChunk *idx, char *dst, size_t dst_size)

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -27,6 +27,7 @@ typedef enum zck_ioption {
     ZCK_VAL_HEADER_HASH_TYPE,   /* Set what the header hash type *should* be */
     ZCK_VAL_HEADER_LENGTH,      /* Set what the header length *should* be */
     ZCK_UNCOMP_HEADER,          /* Header should contain uncompressed size, too */
+    ZCK_NO_MIN_CHUNKSIZE,	/* No check for min size */
     ZCK_COMP_TYPE = 100,        /* Set compression type using zck_comp */
     ZCK_MANUAL_CHUNK,           /* Disable auto-chunking */
     ZCK_CHUNK_MIN,              /* Minimum chunk size when manual chunking */

--- a/src/lib/buzhash/buzhash.c
+++ b/src/lib/buzhash/buzhash.c
@@ -100,11 +100,13 @@ const uint32_t buzhash_table[] = {
     0x7bf7cabc, 0xf9c18d66, 0x593ade65, 0xd95ddf11,
 };
 
-uint32_t buzhash_update (buzHash *b, const char *s, size_t window) {
+bool buzhash_update (buzHash *b, const char *s, size_t window, uint32_t *output) {
     if(b->window == NULL || b->window_size != window) {
         if(b->window)
             free(b->window);
         b->window = calloc(1, window);
+        if (!b->window)
+            return false;
         assert(b->window);
         b->window_loc = 0;
         b->window_fill = 0;
@@ -116,10 +118,12 @@ uint32_t buzhash_update (buzHash *b, const char *s, size_t window) {
         b->window_fill++;
         if(b->window_fill < b->window_size) {
             b->h ^= rol32 (buzhash_table[(uint8_t) (*s)], window - b->window_fill);
-            return 1;
+            *output = 1;
+            return true;
         } else {
             b->h ^= buzhash_table[(uint8_t) (*s)];
-            return b->h;
+            *output = b->h;
+            return true;
         }
     }
     b->h = rol32 (b->h, 1) ^
@@ -127,7 +131,8 @@ uint32_t buzhash_update (buzHash *b, const char *s, size_t window) {
            buzhash_table[(uint8_t) *s];
     b->window[b->window_loc++] = *s;
     b->window_loc %= b->window_size;
-    return b->h;
+    *output = b->h;
+    return true;
 }
 
 void buzhash_reset (buzHash *b) {

--- a/src/lib/buzhash/buzhash.h
+++ b/src/lib/buzhash/buzhash.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 typedef struct buzHash {
     uint32_t h;
@@ -13,7 +14,7 @@ typedef struct buzHash {
     int window_fill;
 } buzHash;
 
-uint32_t buzhash_update (buzHash *b, const char *s, size_t window);
+bool buzhash_update (buzHash *b, const char *s, size_t window, uint32_t *output);
 void buzhash_reset (buzHash *b);
 
 #endif

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -394,6 +394,10 @@ bool comp_add_to_dc(zckCtx *zck, zckComp *comp, const char *src,
 
     /* Get rid of any already read data and allocate space for new data */
     char *temp = zmalloc(comp->dc_data_size - comp->dc_data_loc + src_size);
+    if (!temp) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     if(comp->dc_data_loc != 0)
         zck_log(ZCK_LOG_DEBUG, "Freeing %lu bytes from decompressed buffer",
                 comp->dc_data_loc);
@@ -430,6 +434,10 @@ ssize_t comp_read(zckCtx *zck, char *dst, size_t dst_size, bool use_dict) {
 
     size_t dc = 0;
     char *src = zmalloc(dst_size - dc);
+    if (!src) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     bool finished_rd = false;
     bool finished_dc = false;
     zck_log(ZCK_LOG_DEBUG, "Trying to read %lu bytes", dst_size);

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -595,7 +595,7 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
                             "chunk");
                 else
                     zck_log(ZCK_LOG_DDEBUG, "Automatically ending chunk");
-                if(zck->comp.dc_data_size < zck->chunk_auto_min) {
+                if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_auto_min) {
                     zck_log(ZCK_LOG_DDEBUG,
                             "Chunk too small, refusing to end chunk");
                     continue;
@@ -618,7 +618,7 @@ ssize_t PUBLIC zck_end_chunk(zckCtx *zck) {
     if(!zck->comp.started && !comp_init(zck))
         return -1;
 
-    if(zck->comp.dc_data_size < zck->chunk_min_size) {
+    if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_min_size) {
         zck_log(ZCK_LOG_DDEBUG, "Chunk too small, refusing to end chunk");
         return zck->comp.dc_data_size;
     }

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -116,6 +116,10 @@ static bool comp_add_to_data(zckCtx *zck, zckComp *comp, const char *src,
     ALLOCD_BOOL(zck, src);
 
     comp->data = zrealloc(comp->data, comp->data_size + src_size);
+    if (!comp->data) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     zck_log(ZCK_LOG_DEBUG, "Adding %lu bytes to compressed buffer",
         src_size);
     memcpy(comp->data + comp->data_size, src, src_size);

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -158,6 +158,8 @@ static ssize_t comp_write(zckCtx *zck, const char *src, const size_t src_size) {
         free(dst);
         return -1;
     }
+    if(zck->has_uncompressed_source && !hash_update(zck, &(zck->work_index_hash_uncomp), src, src_size))
+        return -1;
     free(dst);
     return src_size;
 }

--- a/src/lib/comp/nocomp/nocomp.c
+++ b/src/lib/comp/nocomp/nocomp.c
@@ -49,6 +49,10 @@ static ssize_t compress(zckCtx *zck, zckComp *comp, const char *src,
     ALLOCD_INT(zck, comp);
 
     *dst = zmalloc(src_size);
+    if (!dst) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return 0;
+    }
 
     memcpy(*dst, src, src_size);
     *dst_size = src_size;

--- a/src/lib/comp/zstd/zstd.c
+++ b/src/lib/comp/zstd/zstd.c
@@ -140,6 +140,10 @@ static bool end_cchunk(zckCtx *zck, zckComp *comp, char **dst, size_t *dst_size,
     }
 
     *dst = zmalloc(max_size);
+    if (!dst) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
 #ifdef OLD_ZSTD
     /* Currently, compression isn't deterministic when using contexts in
      * zstd 1.3.5, so this works around it */
@@ -205,6 +209,10 @@ static bool end_dchunk(zckCtx *zck, zckComp *comp, const bool use_dict,
     comp->data_size = 0;
 
     char *dst = zmalloc(fd_size);
+    if (!dst) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     size_t retval = 0;
     zck_log(ZCK_LOG_DEBUG, "Decompressing %lu bytes to %lu bytes", src_size,
             fd_size);

--- a/src/lib/comp/zstd/zstd.c
+++ b/src/lib/comp/zstd/zstd.c
@@ -118,6 +118,10 @@ static ssize_t compress(zckCtx *zck, zckComp *comp, const char *src,
     ALLOCD_INT(zck, comp);
 
     comp->dc_data = zrealloc(comp->dc_data, comp->dc_data_size + src_size);
+    if (!comp->dc_data) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return -1;
+    }
 
     memcpy(comp->dc_data + comp->dc_data_size, src, src_size);
     *dst = NULL;

--- a/src/lib/dl/dl.c
+++ b/src/lib/dl/dl.c
@@ -271,6 +271,10 @@ ssize_t PUBLIC zck_dl_get_bytes_uploaded(zckDL *dl) {
 /* Initialize zckDL.  When finished, zckDL *must* be freed by zck_dl_free() */
 zckDL PUBLIC *zck_dl_init(zckCtx *zck) {
     zckDL *dl = zmalloc(sizeof(zckDL));
+    if (!dl) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     dl->mp = zmalloc(sizeof(zckMP));
     dl->zck = zck;
     return dl;

--- a/src/lib/dl/multipart.c
+++ b/src/lib/dl/multipart.c
@@ -120,6 +120,10 @@ size_t multipart_extract(zckDL *dl, char *b, size_t l) {
     /* Add new data to stored buffer */
     if(mp->buffer) {
         buf = zrealloc(mp->buffer, mp->buffer_len + l);
+        if (!buf) {
+            zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+            return 0;
+        }
         memcpy(buf + mp->buffer_len, b, l);
         l = mp->buffer_len + l;
         mp->buffer = NULL;  // No need to free, buf holds realloc'd buffer

--- a/src/lib/dl/multipart.c
+++ b/src/lib/dl/multipart.c
@@ -41,7 +41,7 @@ static char *add_boundary_to_regex(zckCtx *zck, const char *regex,
     if(regex == NULL || boundary == NULL)
         return NULL;
     char *regex_b = zmalloc(strlen(regex) + strlen(boundary) + 1);
-    if(snprintf(regex_b, strlen(regex) + strlen(boundary), regex,
+    if(!regex_b || snprintf(regex_b, strlen(regex) + strlen(boundary), regex,
                 boundary) != strlen(regex) + strlen(boundary) - 2) {
         free(regex_b);
         set_error(zck, "Unable to build regular expression");
@@ -81,7 +81,7 @@ static bool gen_regex(zckDL *dl) {
     if(regex_n == NULL)
         return false;
     dl->dl_regex = zmalloc(sizeof(regex_t));
-    if(!create_regex(dl->zck, dl->dl_regex, regex_n)) {
+    if(!dl->dl_regex || !create_regex(dl->zck, dl->dl_regex, regex_n)) {
         free(regex_n);
         return false;
     }
@@ -90,7 +90,7 @@ static bool gen_regex(zckDL *dl) {
     if(regex_e == NULL)
         return false;
     dl->end_regex = zmalloc(sizeof(regex_t));
-    if(!create_regex(dl->zck, dl->end_regex, regex_e)) {
+    if(!dl->end_regex || !create_regex(dl->zck, dl->end_regex, regex_e)) {
         free(regex_e);
         return false;
     }
@@ -164,6 +164,10 @@ size_t multipart_extract(zckDL *dl, char *b, size_t l) {
             size_t size = buf + l - header_start;
             if(size > 0) {
                 mp->buffer = zmalloc(size);
+                if (!mp->buffer) {
+                   zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+                   return 0;
+                }
                 memcpy(mp->buffer, header_start, size);
                 mp->buffer_len = size;
             }
@@ -226,13 +230,17 @@ size_t multipart_get_boundary(zckDL *dl, char *b, size_t size) {
     if(dl->hdr_regex == NULL) {
         char *regex = "boundary *= *(.*?) *\r";
         dl->hdr_regex = zmalloc(sizeof(regex_t));
-        if(!create_regex(dl->zck, dl->hdr_regex, regex))
+        if(!dl->hdr_regex || !create_regex(dl->zck, dl->hdr_regex, regex))
             return 0;
     }
 
     /* Copy buffer to null-terminated string because POSIX regex requires null-
      * terminated string */
     char *buf = zmalloc(size+1);
+    if (!buf) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return 0;
+    }
     buf[size] = '\0';
     memcpy(buf, b, size);
 
@@ -249,6 +257,11 @@ size_t multipart_get_boundary(zckDL *dl, char *b, size_t size) {
 	    boundary_length -= 2;
 	}
         char *boundary = zmalloc(boundary_length + 1);
+        if (!boundary) {
+            zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+            free(buf);
+            return 0;
+        }
         memcpy(boundary, boundary_start, boundary_length);
         zck_log(ZCK_LOG_DEBUG, "Multipart boundary: %s", boundary);
         dl->boundary = boundary;

--- a/src/lib/dl/range.c
+++ b/src/lib/dl/range.c
@@ -42,6 +42,10 @@ static zckRangeItem *range_insert_new(zckCtx *zck, zckRangeItem *prev,
     VALIDATE_PTR(zck);
 
     zckRangeItem *new = zmalloc(sizeof(zckRangeItem));
+    if (!new) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     new->start = start;
     new->end = end;
     if(prev) {
@@ -151,6 +155,10 @@ void PUBLIC zck_range_free(zckRange **info) {
 char PUBLIC *zck_get_range_char(zckCtx *zck, zckRange *range) {
     int buf_size = BUF_SIZE;
     char *output = zmalloc(buf_size);
+    if (!output) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     int loc = 0;
     int count = 0;
     zckRangeItem *ri = range->first;
@@ -181,6 +189,10 @@ zckRange PUBLIC *zck_get_missing_range(zckCtx *zck, int max_ranges) {
     VALIDATE_PTR(zck);
 
     zckRange *range = zmalloc(sizeof(zckRange));
+    if (!range) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     for(zckChunk *chk = zck->index.first; chk; chk = chk->next) {
         if(chk->valid)
             continue;

--- a/src/lib/dl/range.c
+++ b/src/lib/dl/range.c
@@ -54,7 +54,7 @@ static zckRangeItem *range_insert_new(zckCtx *zck, zckRangeItem *prev,
     }
     if(add_index)
         if(!index_new_chunk(zck, &(info->index), idx->digest, idx->digest_size,
-                            end-start+1, end-start+1, idx, false)) {
+                            idx->digest_uncompressed, end-start+1, end-start+1, idx, false)) {
             free(new);
             return NULL;
         }

--- a/src/lib/dl/range.c
+++ b/src/lib/dl/range.c
@@ -174,6 +174,10 @@ char PUBLIC *zck_get_range_char(zckCtx *zck, zckRange *range) {
         if(length > buf_size-loc) {
             buf_size = (int)(buf_size * 1.5);
             output = zrealloc(output, buf_size);
+            if (!output) {
+                zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+                return output;
+            }
             continue;
         }
         loc += length;

--- a/src/lib/error.c
+++ b/src/lib/error.c
@@ -65,6 +65,10 @@ void set_error_wf(zckCtx *zck, int fatal, const char *function,
         zck->msg = zmalloc(size + old_size + 3);
     else
         zck->msg = zmalloc(size + 2);
+    if (!zck->msg) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return;
+    }
     va_start(args, format);
     vsnprintf(zck->msg, size + 1, format, args);
     va_end(args);

--- a/src/lib/hash/hash.c
+++ b/src/lib/hash/hash.c
@@ -146,6 +146,10 @@ static int validate_checksums(zckCtx *zck, zck_log_type bad_checksums) {
 char *get_digest_string(const char *digest, int size) {
     char *str = zmalloc(size*2+1);
 
+    if (!str) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     for(int i=0; i<size; i++)
         snprintf(str + i*2, 3, "%02x", (unsigned char)digest[i]);
     return str;
@@ -212,12 +216,20 @@ bool hash_init(zckCtx *zck, zckHash *hash, zckHashType *hash_type) {
     if(hash_type->type == ZCK_HASH_SHA1) {
         zck_log(ZCK_LOG_DDEBUG, "Initializing SHA-1 hash");
         hash->ctx = zmalloc(sizeof(SHA_CTX));
+        if (!hash->ctx) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         hash->type = hash_type;
         SHA1_Init((SHA_CTX *) hash->ctx);
         return true;
     } else if(hash_type->type == ZCK_HASH_SHA256) {
         zck_log(ZCK_LOG_DDEBUG, "Initializing SHA-256 hash");
         hash->ctx = zmalloc(sizeof(SHA256_CTX));
+        if (!hash->ctx) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         hash->type = hash_type;
         SHA256_Init((SHA256_CTX *) hash->ctx);
         return true;
@@ -225,6 +237,10 @@ bool hash_init(zckCtx *zck, zckHash *hash, zckHashType *hash_type) {
               hash_type->type <= ZCK_HASH_SHA512_128) {
         zck_log(ZCK_LOG_DDEBUG, "Initializing SHA-512 hash");
         hash->ctx = zmalloc(sizeof(SHA512_CTX));
+        if (!hash->ctx) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         hash->type = hash_type;
         SHA512_Init((SHA512_CTX *) hash->ctx);
         return true;
@@ -279,17 +295,29 @@ char *hash_finalize(zckCtx *zck, zckHash *hash) {
     }
     if(hash->type->type == ZCK_HASH_SHA1) {
         unsigned char *digest = zmalloc(SHA1_DIGEST_LENGTH);
+        if (!digest) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         SHA1_Final((sha1_byte*)digest, (SHA_CTX *)hash->ctx);
         hash_close(hash);
         return (char *)digest;
     } else if(hash->type->type == ZCK_HASH_SHA256) {
         unsigned char *digest = zmalloc(SHA256_DIGEST_SIZE);
+        if (!digest) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         SHA256_Final(digest, (SHA256_CTX *)hash->ctx);
         hash_close(hash);
         return (char *)digest;
     } else if(hash->type->type >= ZCK_HASH_SHA512 &&
               hash->type->type <= ZCK_HASH_SHA512_128) {
         unsigned char *digest = zmalloc(SHA512_DIGEST_SIZE);
+        if (!digest) {
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
         SHA512_Final(digest, (SHA512_CTX *)hash->ctx);
         hash_close(hash);
         return (char *)digest;

--- a/src/lib/hash/hash.c
+++ b/src/lib/hash/hash.c
@@ -517,6 +517,16 @@ char PUBLIC *zck_get_chunk_digest(zckChunk *item) {
     return get_digest_string(item->digest, item->digest_size);
 }
 
+char PUBLIC *zck_get_chunk_digest_uncompressed(zckChunk *item) {
+    if(item == NULL)
+        return NULL;
+    if (!item->zck->has_uncompressed_source) {
+        return NULL;
+    }
+    return get_digest_string(item->digest_uncompressed, item->digest_size_uncompressed);
+}
+
+
 /* Returns 1 if all chunks are valid, -1 if even one isn't and 0 if error */
 int PUBLIC zck_find_valid_chunks(zckCtx *zck) {
     VALIDATE_READ_BOOL(zck);

--- a/src/lib/header.c
+++ b/src/lib/header.c
@@ -120,6 +120,10 @@ static bool read_preface(zckCtx *zck) {
         return false;
     }
     zck->full_hash_digest = zmalloc(zck->hash_type.digest_size);
+    if (!zck->full_hash_digest) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     memcpy(zck->full_hash_digest, header+length, zck->hash_type.digest_size);
     length += zck->hash_type.digest_size;
 
@@ -238,6 +242,10 @@ static bool preface_create(zckCtx *zck) {
     int header_malloc = zck->hash_type.digest_size + 4 + 2*MAX_COMP_SIZE;
 
     char *header = zmalloc(header_malloc);
+    if (!header) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     size_t length = 0;
 
     /* Write out the full data digest */
@@ -272,6 +280,10 @@ static bool sig_create(zckCtx *zck) {
     char *header = zmalloc(MAX_COMP_SIZE);
     size_t length = 0;
 
+    if (!header) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     zck_log(ZCK_LOG_DEBUG, "Calculating %i signatures", zck->sigs.count);
 
     /* Write out signature count and signatures */
@@ -295,6 +307,10 @@ static bool lead_create(zckCtx *zck) {
     memcpy(header, "\0ZCK1", 5);
     length += 5;
 
+    if (!header) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     /* Write out full data and header hash type */
     compint_from_size(header + length, zck->hash_type.type, &length);
     /* Write out header length */
@@ -345,6 +361,10 @@ bool header_create(zckCtx *zck) {
     zck_log(ZCK_LOG_DEBUG, "Merging into header: %lu bytes",
             zck->data_offset);
     zck->header = zmalloc(zck->data_offset);
+    if (!zck->header) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     size_t offs = 0;
     memcpy(zck->header + offs, zck->lead_string, zck->lead_size);
     free(zck->lead_string);
@@ -404,6 +424,10 @@ static bool read_lead(zckCtx *zck) {
     int lead = 5 + 2*MAX_COMP_SIZE;
 
     char *header = zmalloc(lead);
+    if (!header) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    return false;
+    }
     size_t length = 0;
 
     if(read_data(zck, header, lead) < lead) {
@@ -481,6 +505,11 @@ static bool read_lead(zckCtx *zck) {
         return false;
     }
     zck->header_digest = zmalloc(zck->hash_type.digest_size);
+    if (!zck->header_digest) {
+	    zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+	    free(header);
+	    return false;
+    }
     memcpy(zck->header_digest, header + length, zck->hash_type.digest_size);
     length += zck->hash_type.digest_size;
 

--- a/src/lib/header.c
+++ b/src/lib/header.c
@@ -65,6 +65,10 @@ static bool read_optional_element(zckCtx *zck, size_t id, size_t data_size,
 static bool read_header_from_file(zckCtx *zck) {
     /* Allocate header and store any extra bytes at beginning of header */
     zck->header = zrealloc(zck->header, zck->lead_size + zck->header_length);
+    if (!zck->header) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     zck->lead_string = zck->header;
     char *header = zck->header + zck->lead_size;
     size_t loaded = 0;
@@ -269,6 +273,10 @@ static bool preface_create(zckCtx *zck) {
 
     /* Shrink header to actual size */
     header = zrealloc(header, length);
+    if (!header) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
 
     zck->preface_string = header;
     zck->preface_size = length;
@@ -321,6 +329,10 @@ static bool lead_create(zckCtx *zck) {
     length += zck->hash_type.digest_size;
 
     header = zrealloc(header, length);
+    if (!header) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
 
     zck->lead_string = header;
     zck->lead_size = length;
@@ -477,6 +489,10 @@ static bool read_lead(zckCtx *zck) {
     /* Read header digest */
     zck_log(ZCK_LOG_DEBUG, "Reading header digest");
     header = zrealloc(header, length + zck->hash_type.digest_size);
+    if (!header) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     size_t to_read = 0;
     if(lead < length + zck->hash_type.digest_size)
         to_read = length + zck->hash_type.digest_size - lead;

--- a/src/lib/index/index_common.c
+++ b/src/lib/index/index_common.c
@@ -89,6 +89,7 @@ void clear_work_index(zckCtx *zck) {
         return;
 
     hash_close(&(zck->work_index_hash));
+    hash_close(&(zck->work_index_hash_uncomp));
     if(zck->work_index_item)
         index_free_item(&(zck->work_index_item));
 }

--- a/src/lib/index/index_create.c
+++ b/src/lib/index/index_create.c
@@ -37,6 +37,10 @@ static bool create_chunk(zckCtx *zck) {
 
     clear_work_index(zck);
     zck->work_index_item = zmalloc(sizeof(zckChunk));
+    if (!zck->work_index_item) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     if(!hash_init(zck, &(zck->work_index_hash), &(zck->chunk_hash_type)) ||
       (!hash_init(zck, &(zck->work_index_hash_uncomp), &(zck->chunk_hash_type))))
         return false;
@@ -51,6 +55,11 @@ static bool finish_chunk(zckIndex *index, zckChunk *item, char *digest,
 
     item->digest = zmalloc(index->digest_size);
     item->digest_uncompressed = zmalloc(index->digest_size);
+    if (!item->digest || !item->digest_uncompressed) {
+       free(item->digest);
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     if(digest) {
         memcpy(item->digest, digest, index->digest_size);
         item->digest_size = index->digest_size;
@@ -111,6 +120,10 @@ bool index_create(zckCtx *zck) {
 
     /* Write index */
     index = zmalloc(index_malloc);
+    if (!index) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     compint_from_size(index+index_size, zck->index.hash_type, &index_size);
     compint_from_size(index+index_size, zck->index.count, &index_size);
     if(zck->index.first) {
@@ -155,6 +168,10 @@ bool index_new_chunk(zckCtx *zck, zckIndex *index, char *digest,
         return false;
     }
     zckChunk *chk = zmalloc(sizeof(zckChunk));
+    if (!chk) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     index->digest_size = digest_size;
     chk->comp_length = comp_size;
     chk->length = orig_size;
@@ -209,6 +226,11 @@ bool index_finish_chunk(zckCtx *zck) {
     } else {
         digest = zmalloc(zck->chunk_hash_type.digest_size);
         digest_uncompressed = zmalloc(zck->chunk_hash_type.digest_size);
+        if (!digest || !digest_uncompressed) {
+           free(digest);
+           zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+           return false;
+        }
     }
     if(!finish_chunk(&(zck->index), zck->work_index_item, digest, digest_uncompressed, true, zck)) {
         free(digest);

--- a/src/lib/index/index_create.c
+++ b/src/lib/index/index_create.c
@@ -148,6 +148,10 @@ bool index_create(zckCtx *zck) {
     }
     /* Shrink index to actual size */
     index = zrealloc(index, index_size);
+    if (!index) {
+        zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+        return false;
+    }
     zck->index_string = index;
     zck->index_size = index_size;
     zck_log(ZCK_LOG_DEBUG, "Generated index: %lu bytes", zck->index_size);

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -85,6 +85,14 @@ bool index_read(zckCtx *zck, char *data, size_t size, size_t max_length) {
                             new);
         length += zck->index.digest_size;
 
+        /* Read uncompressed entry digest, if any */
+        if (zck->has_uncompressed_source) {
+            /* same size for digest as compressed */
+            new->digest_uncompressed = zmalloc(zck->index.digest_size);
+            memcpy(new->digest_uncompressed, data+length, zck->index.digest_size);
+            new->digest_size_uncompressed = zck->index.digest_size;
+            length += zck->index.digest_size;
+	}
         /* Read and store entry length */
         size_t chunk_length = 0;
         if(!compint_to_size(zck, &chunk_length, data+length, &length,

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -106,6 +106,10 @@ bool index_read(zckCtx *zck, char *data, size_t size, size_t max_length) {
             }
             memcpy(new->digest_uncompressed, data+length, zck->index.digest_size);
             new->digest_size_uncompressed = zck->index.digest_size;
+            HASH_FIND(hh, zck->index.ht, new->digest, new->digest_size, tmp);
+            if(!tmp)
+               HASH_ADD_KEYPTR(hhuncomp, zck->index_uncomp.ht, new->digest_uncompressed, new->digest_size,
+                               new);
             length += zck->index.digest_size;
 	}
         /* Read and store entry length */

--- a/src/lib/io.c
+++ b/src/lib/io.c
@@ -113,6 +113,10 @@ int chunks_from_temp(zckCtx *zck) {
         return false;
 
     char *data = zmalloc(BUF_SIZE);
+    if (!data) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
 
     while((read_count = read(zck->temp_fd, data, BUF_SIZE)) > 0) {
         if(!write_data(zck, zck->fd, data, read_count)) {

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -102,6 +102,10 @@ static char *ascii_checksum_to_bin (zckCtx *zck, char *checksum,
     char *raw_checksum = zmalloc(checksum_length/2);
     char *rp = raw_checksum;
     int buf = 0;
+    if (!raw_checksum) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return NULL;
+    }
     for (int i=0; i<checksum_length; i++) {
         // Get integer value of hex checksum character.  If -1 is returned, then
         // the character wasn't actually hex, so return NULL
@@ -122,13 +126,11 @@ static char *ascii_checksum_to_bin (zckCtx *zck, char *checksum,
 
 void *zmalloc(size_t size) {
     void *ret = calloc(1, size);
-    assert(ret);
     return ret;
 }
 
 void *zrealloc(void *ptr, size_t size) {
     void *ret = realloc(ptr, size);
-    assert(ret);
     return ret;
 }
 
@@ -148,6 +150,10 @@ int get_tmp_fd(zckCtx *zck) {
     }
 
     fname = zmalloc(strlen(template) + strlen(tmpdir) + 2);
+    if (!fname) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return -ENOMEM;
+    }
     int i=0;
     for(i=0; i<strlen(tmpdir); i++)
         fname[i] = tmpdir[i];
@@ -188,6 +194,10 @@ bool import_dict(zckCtx *zck) {
 
     zck_log(ZCK_LOG_DEBUG, "Reading compression dict");
     char *data = zmalloc(size);
+    if (!data) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     if(comp_read(zck, data, size, 0) != size) {
         set_error(zck, "Error reading compressed dict");
         return false;
@@ -208,6 +218,10 @@ bool PUBLIC zck_set_soption(zckCtx *zck, zck_soption option, const char *value,
                             size_t length) {
     VALIDATE_BOOL(zck);
     char *data = zmalloc(length);
+    if (!data) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     memcpy(data, value, length);
 
     /* Validation options */
@@ -351,6 +365,10 @@ void PUBLIC zck_free(zckCtx **zck) {
 
 zckCtx PUBLIC *zck_create() {
     zckCtx *zck = zmalloc(sizeof(zckCtx));
+    if (!zck) {
+       zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+       return false;
+    }
     zck_clear_error(NULL);
     zck->prep_hash_type = -1;
     zck->prep_hdr_size = -1;

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -308,6 +308,8 @@ bool PUBLIC zck_set_ioption(zckCtx *zck, zck_ioption option, ssize_t value) {
 
     } else if(option == ZCK_UNCOMP_HEADER) {
         zck->has_uncompressed_source = 1;
+    } else if(option == ZCK_NO_MIN_CHUNKSIZE) {
+        zck->no_check_min_size = 1;
     /* Hash options */
     } else if(option < 100) {
         /* Currently no hash options other than setting hash type, so bail */

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -131,6 +131,12 @@ void *zmalloc(size_t size) {
 
 void *zrealloc(void *ptr, size_t size) {
     void *ret = realloc(ptr, size);
+    /*
+     * Realloc does not touch the original block if fails.
+     * Policy is to free memory and returns with error (Null)
+     */
+    if (!ret && ptr)
+        free(ptr);
     return ret;
 }
 

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -292,6 +292,8 @@ bool PUBLIC zck_set_ioption(zckCtx *zck, zck_ioption option, ssize_t value) {
         }
         zck->prep_hdr_size = value;
 
+    } else if(option == ZCK_UNCOMP_HEADER) {
+        zck->has_uncompressed_source = 1;
     /* Hash options */
     } else if(option < 100) {
         /* Currently no hash options other than setting hash type, so bail */

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -272,6 +272,7 @@ struct zckCtx {
     int has_streams;
     int has_optional_elems;
     int has_uncompressed_source;
+    int no_check_min_size;
 
     char *read_buf;
     size_t read_buf_size;

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -150,6 +150,8 @@ struct zckDL {
 struct zckChunk {
     char *digest;
     int digest_size;
+    char *digest_uncompressed;
+    int digest_size_uncompressed;
     int valid;
     size_t number;
     size_t start;
@@ -262,9 +264,12 @@ struct zckCtx {
     zckIndex index;
     zckChunk *work_index_item;
     zckHash work_index_hash;
+    zckChunk *work_index_item_uncomp;
+    zckHash work_index_hash_uncomp;
     size_t stream;
     int has_streams;
     int has_optional_elems;
+    int has_uncompressed_source;
 
     char *read_buf;
     size_t read_buf_size;
@@ -340,7 +345,7 @@ bool index_read(zckCtx *zck, char *data, size_t size, size_t max_length)
 bool index_create(zckCtx *zck)
     __attribute__ ((warn_unused_result));
 bool index_new_chunk(zckCtx *zck, zckIndex *index, char *digest, int digest_size,
-                     size_t comp_size, size_t orig_size, zckChunk *src, bool valid)
+                     char* digest_uncompressed, size_t comp_size, size_t orig_size, zckChunk *src, bool valid)
     __attribute__ ((warn_unused_result));
 bool index_add_to_chunk(zckCtx *zck, char *data, size_t comp_size,
                         size_t orig_size)

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -161,6 +161,7 @@ struct zckChunk {
     struct zckChunk *src;
     zckCtx *zck;
     UT_hash_handle hh;
+    UT_hash_handle hhuncomp;
 };
 
 /* Contains everything about an index and a pointer to the first index item */
@@ -264,6 +265,7 @@ struct zckCtx {
     zckIndex index;
     zckChunk *work_index_item;
     zckHash work_index_hash;
+    zckIndex index_uncomp;
     zckChunk *work_index_item_uncomp;
     zckHash work_index_hash_uncomp;
     size_t stream;

--- a/src/zck.c
+++ b/src/zck.c
@@ -230,7 +230,8 @@ int main (int argc, char *argv[]) {
     }
 
     if(arguments.uncompressed) {
-        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1)) {
+        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1) || 
+          (!zck_set_ioption(zck, ZCK_NO_MIN_CHUNKSIZE, 1))) {
             dprintf(STDERR_FILENO, "%s\n", zck_get_error(zck));
             exit(1);
         }

--- a/src/zck.c
+++ b/src/zck.c
@@ -57,6 +57,8 @@ static struct argp_option options[] = {
      "Set zstd compression dictionary to FILE"},
     {"manual-chunk", 'm', 0,        0,
      "Don't do any automatic chunking (implies -s)"},
+    {"uncompressed", 'u', 0,        0,
+     "Add extension in header for uncompressed data"},
     {"version",      'V', 0,        0, "Show program version"},
     { 0 }
 };
@@ -69,6 +71,7 @@ struct arguments {
   char *output;
   char *dict;
   bool exit;
+  bool uncompressed;
 };
 
 static error_t parse_opt (int key, char *arg, struct argp_state *state) {
@@ -94,6 +97,9 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
             break;
         case 'D':
             arguments->dict = arg;
+            break;
+        case 'u':
+            arguments->uncompressed = true;
             break;
         case 'V':
             version();
@@ -223,6 +229,12 @@ int main (int argc, char *argv[]) {
         }
     }
 
+    if(arguments.uncompressed) {
+        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1)) {
+            dprintf(STDERR_FILENO, "%s\n", zck_get_error(zck));
+            exit(1);
+        }
+    }
     char *data;
     int in_fd = open(arguments.args[0], O_RDONLY);
     off_t in_size = 0;

--- a/src/zck_read_header.c
+++ b/src/zck_read_header.c
@@ -176,9 +176,14 @@ int main (int argc, char *argv[]) {
                 dprintf(STDERR_FILENO, "%s", zck_get_error(zck));
                 exit(1);
             }
-            printf("%12lu %s %12lu %12lu %12lu",
+            char *digest_uncompressed = zck_get_chunk_digest_uncompressed(chk);
+            if (!digest_uncompressed)
+                digest_uncompressed = "";
+
+            printf("%12lu %s %s %12lu %12lu %12lu",
                    (long unsigned)zck_get_chunk_number(chk),
                    digest,
+                   digest_uncompressed,
                    (long unsigned)zck_get_chunk_start(chk),
                    (long unsigned)zck_get_chunk_comp_size(chk),
                    (long unsigned)zck_get_chunk_size(chk));

--- a/src/zck_read_header.c
+++ b/src/zck_read_header.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -167,8 +168,6 @@ int main (int argc, char *argv[]) {
     if(!arguments.quiet && arguments.show_chunks)
         printf("\n");
     if(arguments.show_chunks) {
-        printf("       Chunk Checksum %*c        Start    Comp size         Size\n",
-               (((int)zck_get_chunk_digest_size(zck)*2)-9), ' ');
         for(zckChunk *chk=zck_get_first_chunk(zck); chk;
             chk=zck_get_next_chunk(chk)) {
             char *digest = zck_get_chunk_digest(chk);
@@ -180,6 +179,17 @@ int main (int argc, char *argv[]) {
             if (!digest_uncompressed)
                 digest_uncompressed = "";
 
+	    if (chk == zck_get_first_chunk(zck)) {
+		    bool has_uncompressed = (strlen(digest_uncompressed) > 0);
+		    if (has_uncompressed)
+                        printf("       Chunk Checksum %*cChecksum uncompressed %*c       Start    Comp size         Size\n",
+                           (((int)zck_get_chunk_digest_size(zck) * 2) - (int)strlen("Checksum")), ' ',
+                           ((int)zck_get_chunk_digest_size(zck) * 2) - (int)strlen("Uncompressed Checksum"), ' ');
+                    else
+                        printf("       Chunk Checksum %*c        Start    Comp size         Size\n",
+                              (((int)zck_get_chunk_digest_size(zck) * 2) - (int)strlen("Checksum")), ' ');
+
+	    }
             printf("%12lu %s %s %12lu %12lu %12lu",
                    (long unsigned)zck_get_chunk_number(chk),
                    digest,

--- a/zchunk_format.txt
+++ b/zchunk_format.txt
@@ -1,3 +1,7 @@
+NOTE: Any flags marked EXPERIMENTAL are still in development and the format, as
+      it applies to those flags, is still in flux.  It is strongly recommended
+      that no public zchunk files be created using EXPERIMENTAL flags
+
 A zchunk file contains two parts, the header and the body.  The header consists
 of four parts:
  * The lead: Everything necessary to validate the header
@@ -68,6 +72,7 @@ Flags
  Current flags are:
   bit 0: File has data streams
   bit 1: File has optional elements
+  bit 2: EXPERIMENTAL: File may be applied against an uncompressed source
 
 Compression type
  This is an integer containing the type of compression used to compress dict and
@@ -116,13 +121,14 @@ The index:
 +===============================+
 
 (Chunk stream will only exist if flag 0 is set to 1)
-[+===================+================+===================+
-[| Chunk stream (ci) | Chunk checksum | Chunk length (ci) |
-[+===================+================+===================+
+EXPERIMENTAL: (Uncompressed chunk checksum will only exist if flag 2 is set to 1)
+[+===================+================+=============================+
+[| Chunk stream (ci) | Chunk checksum | Uncompressed chunk checksum |
+[+===================+================+=============================+
 
-+==========================+]
-| Uncompressed length (ci) |] ...
-+==========================+]
++===================+==========================+]
+| Chunk length (ci) | Uncompressed length (ci) |] ...
++===================+==========================+]
 
 Index size
  This is an integer containing the size of the index.
@@ -167,6 +173,12 @@ Chunk stream
 Chunk checksum
  This is the checksum of the compressed chunk, used to detect whether any two
  chunks are identical.
+
+EXPERIMENTAL: NOTE: Uncompressed chunk checksum will only exist if flag 2 is set
+                    to 1
+Uncompressed chunk checksum
+ This is the checksum of the uncompressed chunk, used to detect whether a chunk
+ from an uncompressed source is identical to the compressed chunk
 
 Chunk length
  This is an integer containing the length of the chunk.

--- a/zchunk_format.txt
+++ b/zchunk_format.txt
@@ -9,13 +9,16 @@ of four parts:
  * The index: Details about each chunk
  * The signatures: Signatures used to sign the zchunk file
 
-Definitions:
+Definitions and document conventions:
 (ci)
  Compressed (unsigned) integer - An variable length little endian integer where
  the first seven bits of the number are stored in the first byte, followed by
  the next seven bits in the next byte, and so on.  The top bit of all bytes
  except the final byte must be zero, and the top bit of the final byte must be
  one, indicating the end of the number.
+
+[#]
+ Section is only used if flag # is set.
 
 The lead:
 +-+-+-+-+-+====================+==================+=================+
@@ -46,18 +49,17 @@ The preface:
 | Data checksum | Flags (ci) | Compression type (ci ) |
 +===============+============+========================+
 
-(Optional elements will only be set if flag 1 is set to 1)
-+=============================+
-| Optional element count (ci) |
-+=============================+
++=================================+
+| Optional element count (ci) [1] |
++=================================+
 
-[+==========================+=================================+
-[| Optional element id (ci) | Optional element data size (ci) |
-[+==========================+=================================+
+[+==============================+=====================================+
+[| Optional element id (ci) [1] | Optional element data size (ci) [1] |
+[+==============================+=====================================+
 
-+=======================+]
-| Optional element data |] ...
-+=======================+]
++===========================+]
+| Optional element data [1] |] ...
++===========================+]
 
 Data checksum
  This is the checksum of everything after the header, including the compressed
@@ -112,19 +114,17 @@ The index:
 +=================+==========================+==================+
 
 (Dict stream will only exist if flag 0 is set to 1)
-+==================+===============+==================+
-| Dict stream (ci) | Dict checksum | Dict length (ci) |
-+==================+===============+==================+
++======================+===============+==================+
+| Dict stream (ci) [0] | Dict checksum | Dict length (ci) |
++======================+===============+==================+
 
 +===============================+
 | Uncompressed dict length (ci) |
 +===============================+
 
-(Chunk stream will only exist if flag 0 is set to 1)
-EXPERIMENTAL: (Uncompressed chunk checksum will only exist if flag 2 is set to 1)
-[+===================+================+=============================+
-[| Chunk stream (ci) | Chunk checksum | Uncompressed chunk checksum |
-[+===================+================+=============================+
+[+=======================+================+=================================+
+[| Chunk stream (ci) [0] | Chunk checksum | Uncompressed chunk checksum [2] |
+[+=======================+================+=================================+
 
 +===================+==========================+]
 | Chunk length (ci) | Uncompressed length (ci) |] ...


### PR DESCRIPTION
Hi Jonathan,
please consider this as RFC and after just testing that the uncompressed checksum is part of the index and it is reported back by zck_read_header, and after running zck / unzck on quite big files.
This set implements the new format as specified in the uncompressed_source branch. The checksum for uncompressed data is stored then in the index and the hash is computed together with the one for the compressed chunk.
In the series there are also:

Drop warning when OLD_ZSTD is set
----------------------------------------------------- 
It is a nitpick, this just drop a warning when OLD_ZSTD is set

Drop assert in zmalloc and raise runtime error 
--------------------------------------------------------------

This is an issue using the library on embedded system. An allocation on the heap could fail on small system, but the process is not allowed to fail and it should manage this. So I replace the assert with error handling in case of zmalloc(), same should be done for zrealloc(), but I want to know first your opinion on thisand if can be mainlined.

Thanks,
Stefano

