### PR TITLE
Fix three problems reported by the cppcheck tool.

### DIFF
--- a/src/lib/comp/zstd/zstd.c
+++ b/src/lib/comp/zstd/zstd.c
@@ -37,7 +37,9 @@ static bool init(zckCtx *zck, zckComp *comp) {
     VALIDATE_BOOL(zck);
     ALLOCD_BOOL(zck, comp);
 
+#ifndef OLD_ZSTD
     size_t retval = 0;
+#endif
 
     comp->cctx = ZSTD_createCCtx();
 #ifndef OLD_ZSTD

--- a/src/lib/io.c
+++ b/src/lib/io.c
@@ -115,11 +115,13 @@ int chunks_from_temp(zckCtx *zck) {
     char *data = zmalloc(BUF_SIZE);
 
     while((read_count = read(zck->temp_fd, data, BUF_SIZE)) > 0) {
-        if(read_count == -1 || !write_data(zck, zck->fd, data, read_count)) {
+        if(!write_data(zck, zck->fd, data, read_count)) {
             free(data);
             return false;
         }
     }
     free(data);
+    if(read_count == -1)
+        return false;
     return true;
 }

--- a/test/read_single_chunk.c
+++ b/test/read_single_chunk.c
@@ -69,7 +69,7 @@ int main (int argc, char *argv[]) {
         exit(1);
     }
     zckChunk *chunk1 = zck_get_chunk(zck, 1);
-    if(chunk == NULL) {
+    if(chunk1 == NULL) {
         printf("%s", zck_get_error(zck));
         zck_free(&zck);
         exit(1);


### PR DESCRIPTION
Hi,

Thanks for all your work on zchunk and the related libraries and tools!

What do you think about these three changes that fix problems that the cppcheck tool reported? The first one, I believe, may be a genuine problem - a read error would cause the processing to stop and a true value to be returned. The second one might possibly lead to a test failing to detect a problem. The third one is mostly an attempt to also silence a compiler warning - I believe that most compilers would optimize the variable away.

Thanks again, and keep up the great work!

G'luck,
Peter
