### PR TITLE
Stop reading full file into RAM when creating the zchunk file

### DIFF
--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -83,6 +83,8 @@ bool zck_init_write (zckCtx *zck, int dst_fd)
  * actually appear in the zchunk file until zck_close() is called */
 ssize_t zck_write(zckCtx *zck, const char *src, const size_t src_size)
     __attribute__ ((warn_unused_result));
+ssize_t zck_write_from_fd(zckCtx *zck, int fd, const size_t src_size)
+    __attribute__ ((warn_unused_result));
 /* Create a chunk boundary */
 ssize_t zck_end_chunk(zckCtx *zck)
     __attribute__ ((warn_unused_result));


### PR DESCRIPTION
File is full read into RAM before creating the zchunk file, and this
requires large amount of RAM. However, the procedure to create the ZCK
does not require to have the whole file in RAM, but just the chunk that
is worked and the header. In case autochunk mode is selected, read the
original file on demand and loads the chunk when they are required.
This allows to create zck for much larger files as in the past.

To avoid to break current APIU, a new function is introduced:

	zck_write_from_fd()

This accepts a file descriptor instead of the buffer where the whole
file was loaded.

Signed-off-by: Stefano Babic <sbabic@denx.de>