### PR TITLE
Devel

### DIFF
--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -83,6 +83,8 @@ bool zck_init_write (zckCtx *zck, int dst_fd)
  * actually appear in the zchunk file until zck_close() is called */
 ssize_t zck_write(zckCtx *zck, const char *src, const size_t src_size)
     __attribute__ ((warn_unused_result));
+ssize_t zck_write_from_fd(zckCtx *zck, int fd, const size_t src_size)
+    __attribute__ ((warn_unused_result));
 /* Create a chunk boundary */
 ssize_t zck_end_chunk(zckCtx *zck)
     __attribute__ ((warn_unused_result));

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -27,7 +27,6 @@ typedef enum zck_ioption {
     ZCK_VAL_HEADER_HASH_TYPE,   /* Set what the header hash type *should* be */
     ZCK_VAL_HEADER_LENGTH,      /* Set what the header length *should* be */
     ZCK_UNCOMP_HEADER,          /* Header should contain uncompressed size, too */
-    ZCK_NO_MIN_CHUNKSIZE,	/* No check for min size */
     ZCK_COMP_TYPE = 100,        /* Set compression type using zck_comp */
     ZCK_MANUAL_CHUNK,           /* Disable auto-chunking */
     ZCK_CHUNK_MIN,              /* Minimum chunk size when manual chunking */

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -646,7 +646,7 @@ static ssize_t _zck_write(zckCtx *zck, const char *src, int src_fd, const size_t
                             "chunk");
                 else
                     zck_log(ZCK_LOG_DDEBUG, "Automatically ending chunk");
-                if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_auto_min) {
+                if(zck->comp.dc_data_size < zck->chunk_auto_min) {
                     zck_log(ZCK_LOG_DDEBUG,
                             "Chunk too small, refusing to end chunk");
                     continue;
@@ -691,7 +691,7 @@ ssize_t PUBLIC zck_end_chunk(zckCtx *zck) {
     if(!zck->comp.started && !comp_init(zck))
         return -1;
 
-    if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_min_size) {
+    if(zck->comp.dc_data_size < zck->chunk_min_size) {
         zck_log(ZCK_LOG_DDEBUG, "Chunk too small, refusing to end chunk");
         //return zck->comp.dc_data_size;
 	return -EAGAIN;

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -28,9 +28,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include <string.h>
 #include <math.h>
 #include <zck.h>
+#include <errno.h>
 
 #include "zck_private.h"
 #include "comp/nocomp/nocomp.h"
@@ -141,7 +143,7 @@ static ssize_t comp_end_dchunk(zckCtx *zck, bool use_dict, size_t fd_size) {
     return rb;
 }
 
-static ssize_t comp_write(zckCtx *zck, const char *src, const size_t src_size) {
+PUBLIC ssize_t comp_write(zckCtx *zck, const char *src, const size_t src_size) {
     VALIDATE_WRITE_INT(zck);
 
     if(src_size == 0)
@@ -542,28 +544,45 @@ hash_error:
     return -2;
 }
 
-const char PUBLIC *zck_comp_name_from_type(int comp_type) {
-    if(comp_type > 2) {
-        snprintf(unknown+8, 21, "%i)", comp_type);
-        return unknown;
-    }
-    return COMP_NAME[comp_type];
-}
-
-ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
+static ssize_t _zck_write(zckCtx *zck, const char *src, int src_fd, const size_t src_size, bool inmemory) {
     VALIDATE_WRITE_INT(zck);
+    char *loc, *buf;
+    ssize_t bytesinbuf = 0; /* Bytes available in buffer, used to check if file is truncated */
+    size_t bufsize = 2 * CHUNK_DEFAULT_MAX;
+    ssize_t ret_val;
 
     zck_log(ZCK_LOG_DDEBUG, "Starting up");
 
     if(src_size == 0)
         return 0;
-
     if(!zck->comp.started && !comp_init(zck))
         return -1;
 
+    if (zck->chunk_max_size)
+        bufsize = 2 * zck->chunk_max_size;
+    if(!inmemory && zck->manual_chunk) {
+        zck_log(ZCK_LOG_ERROR, "Manual chunk only for in RAM files");
+        return -1;
+    }
+    if (inmemory) {
+    	loc = (char *)src;
+    } else {
+        buf = zmalloc(bufsize);
+        if (!buf) {
+            zck_log(ZCK_LOG_ERROR, "OOM in %s", __func__);
+            return -1;
+        }
+        loc = buf;
+        bytesinbuf = read(src_fd, loc, bufsize);
+        if (bytesinbuf < 0) {
+            zck_log(ZCK_LOG_ERROR, "Reading from src file fails");
+            free(buf);
+            return -1;
+        }
+    }
+
     zck_log(ZCK_LOG_DDEBUG, "Starting up");
 
-    const char *loc = src;
     size_t loc_size = src_size;
     size_t loc_written = 0;
     uint32_t buzhash_res;
@@ -586,6 +605,7 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
             return src_size;
     } else {
         for(size_t i=0; i<loc_size; ) {
+	    size_t pos;
             if (!buzhash_update(&(zck->buzhash), loc+i, zck->buzhash_width, &buzhash_res)) {
                 zck_log(ZCK_LOG_ERROR, "OOM in buzhash_update");
                 return -1;
@@ -597,6 +617,28 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
                     return -1;
                 loc += i;
                 loc_size -= i;
+		pos = i;
+
+                if (!inmemory) {
+	            size_t bytes_avail = bytesinbuf - pos;
+                    memcpy(buf, loc, bytes_avail);
+                    bytesinbuf = read(src_fd, buf + bytes_avail, bufsize - bytes_avail); 
+                    if (bytesinbuf < 0) {
+                        zck_log(ZCK_LOG_ERROR, "Reading from src file fails");
+                        free(buf);
+                        return -1;
+                    }
+		    /*
+		     * Reach EOF, checks we have all requested bytes
+		     */
+                    if ((bytesinbuf + bytes_avail != bufsize) &&
+                        (bytesinbuf + bytes_avail != loc_size)) {
+                        zck_log(ZCK_LOG_ERROR, "Less bytes as required bytesinbuf %lu bytesavail %lu loc_size %lu src_size %lu", bytesinbuf, bytes_avail, loc_size, src_size);
+                    }
+                    bytesinbuf += bytes_avail;
+                    loc = buf;
+                }
+
                 i = 0;
                 if(zck->comp.dc_data_size >= zck->chunk_max_size)
                     zck_log(ZCK_LOG_DDEBUG,
@@ -609,9 +651,15 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
                             "Chunk too small, refusing to end chunk");
                     continue;
                 }
-                if(zck_end_chunk(zck) < 0)
+
+                ret_val = zck_end_chunk(zck);
+                if (ret_val == -EAGAIN) {
+                   zck_log(ZCK_LOG_ERROR, "EAGAIN");
+		   continue;
+                }
+                if (ret_val < 0)
                     return -1;
-            } else {
+	    } else {
                 i++;
             }
         }
@@ -619,6 +667,22 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
             return -1;
         return src_size;
     }
+}
+
+const char PUBLIC *zck_comp_name_from_type(int comp_type) {
+    if(comp_type > 2) {
+        snprintf(unknown+8, 21, "%i)", comp_type);
+        return unknown;
+    }
+    return COMP_NAME[comp_type];
+}
+
+ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
+    return _zck_write(zck, src, -1, src_size, true);
+}
+
+ssize_t PUBLIC zck_write_from_fd(zckCtx *zck, int fd, const size_t src_size) {
+    return _zck_write(zck, NULL, fd, src_size, false);
 }
 
 ssize_t PUBLIC zck_end_chunk(zckCtx *zck) {
@@ -629,7 +693,8 @@ ssize_t PUBLIC zck_end_chunk(zckCtx *zck) {
 
     if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_min_size) {
         zck_log(ZCK_LOG_DDEBUG, "Chunk too small, refusing to end chunk");
-        return zck->comp.dc_data_size;
+        //return zck->comp.dc_data_size;
+	return -EAGAIN;
     }
 
     buzhash_reset(&(zck->buzhash));

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -314,8 +314,6 @@ bool PUBLIC zck_set_ioption(zckCtx *zck, zck_ioption option, ssize_t value) {
 
     } else if(option == ZCK_UNCOMP_HEADER) {
         zck->has_uncompressed_source = 1;
-    } else if(option == ZCK_NO_MIN_CHUNKSIZE) {
-        zck->no_check_min_size = 1;
     /* Hash options */
     } else if(option < 100) {
         /* Currently no hash options other than setting hash type, so bail */

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -272,7 +272,6 @@ struct zckCtx {
     int has_streams;
     int has_optional_elems;
     int has_uncompressed_source;
-    int no_check_min_size;
 
     char *read_buf;
     size_t read_buf_size;

--- a/src/zck.c
+++ b/src/zck.c
@@ -230,8 +230,7 @@ int main (int argc, char *argv[]) {
     }
 
     if(arguments.uncompressed) {
-        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1) || 
-          (!zck_set_ioption(zck, ZCK_NO_MIN_CHUNKSIZE, 1))) {
+        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1)) {
             dprintf(STDERR_FILENO, "%s\n", zck_get_error(zck));
             exit(1);
         }


### PR DESCRIPTION
This PR addresses the following issues:
- Stop reading full file into RAM when creating the zchunk file (just in library). If this will be merged, an additional PR will change zck.c to make usage of it.
- Figure out why we need ZCK_NO_MIN_CHUNKSIZE and see if we can revert that. Bug discovered and fix, this work-around is not needed and can be reverted.