### PR TITLE
Allow specification of `--compressed-format` in `zck`

### DIFF
--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -27,7 +27,6 @@ typedef enum zck_ioption {
     ZCK_VAL_HEADER_HASH_TYPE,   /* Set what the header hash type *should* be */
     ZCK_VAL_HEADER_LENGTH,      /* Set what the header length *should* be */
     ZCK_UNCOMP_HEADER,          /* Header should contain uncompressed size, too */
-    ZCK_NO_MIN_CHUNKSIZE,	/* No check for min size */
     ZCK_COMP_TYPE = 100,        /* Set compression type using zck_comp */
     ZCK_MANUAL_CHUNK,           /* Disable auto-chunking */
     ZCK_CHUNK_MIN,              /* Minimum chunk size when manual chunking */

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -604,7 +604,7 @@ ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
                             "chunk");
                 else
                     zck_log(ZCK_LOG_DDEBUG, "Automatically ending chunk");
-                if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_auto_min) {
+                if(zck->comp.dc_data_size < zck->chunk_auto_min) {
                     zck_log(ZCK_LOG_DDEBUG,
                             "Chunk too small, refusing to end chunk");
                     continue;
@@ -627,7 +627,7 @@ ssize_t PUBLIC zck_end_chunk(zckCtx *zck) {
     if(!zck->comp.started && !comp_init(zck))
         return -1;
 
-    if(!zck->no_check_min_size && zck->comp.dc_data_size < zck->chunk_min_size) {
+    if(zck->comp.dc_data_size < zck->chunk_min_size) {
         zck_log(ZCK_LOG_DDEBUG, "Chunk too small, refusing to end chunk");
         return zck->comp.dc_data_size;
     }

--- a/src/lib/hash/hash.c
+++ b/src/lib/hash/hash.c
@@ -546,11 +546,8 @@ char PUBLIC *zck_get_chunk_digest(zckChunk *item) {
 }
 
 char PUBLIC *zck_get_chunk_digest_uncompressed(zckChunk *item) {
-    if(item == NULL)
+    if(item == NULL || !item->zck->has_uncompressed_source)
         return NULL;
-    if (!item->zck->has_uncompressed_source) {
-        return NULL;
-    }
     return get_digest_string(item->digest_uncompressed, item->digest_size);
 }
 

--- a/src/lib/hash/hash.c
+++ b/src/lib/hash/hash.c
@@ -551,7 +551,7 @@ char PUBLIC *zck_get_chunk_digest_uncompressed(zckChunk *item) {
     if (!item->zck->has_uncompressed_source) {
         return NULL;
     }
-    return get_digest_string(item->digest_uncompressed, item->digest_size_uncompressed);
+    return get_digest_string(item->digest_uncompressed, item->digest_size);
 }
 
 

--- a/src/lib/header.c
+++ b/src/lib/header.c
@@ -50,7 +50,7 @@ static bool check_flags(zckCtx *zck, size_t flags) {
 
     flags = flags & (SIZE_MAX - 1);
     if(flags != 0) {
-        set_fatal_error(zck, "Unknown flags(s) set");
+        set_fatal_error(zck, "Unknown flags(s) set: %i", flags);
         return false;
     }
     return true;

--- a/src/lib/index/index_create.c
+++ b/src/lib/index/index_create.c
@@ -66,7 +66,6 @@ static bool finish_chunk(zckIndex *index, zckChunk *item, char *digest,
     }
     if(digest_uncompressed) {
         memcpy(item->digest_uncompressed, digest_uncompressed, index->digest_size);
-        item->digest_size_uncompressed = index->digest_size;
     }
     item->start = index->length;
     item->valid = valid;

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -105,7 +105,6 @@ bool index_read(zckCtx *zck, char *data, size_t size, size_t max_length) {
                 return false;
             }
             memcpy(new->digest_uncompressed, data+length, zck->index.digest_size);
-            new->digest_size_uncompressed = zck->index.digest_size;
             HASH_FIND(hh, zck->index.ht, new->digest, new->digest_size, tmp);
             if(!tmp)
                HASH_ADD_KEYPTR(hhuncomp, zck->index_uncomp.ht, new->digest_uncompressed, new->digest_size,

--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -314,8 +314,6 @@ bool PUBLIC zck_set_ioption(zckCtx *zck, zck_ioption option, ssize_t value) {
 
     } else if(option == ZCK_UNCOMP_HEADER) {
         zck->has_uncompressed_source = 1;
-    } else if(option == ZCK_NO_MIN_CHUNKSIZE) {
-        zck->no_check_min_size = 1;
     /* Hash options */
     } else if(option < 100) {
         /* Currently no hash options other than setting hash type, so bail */

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -272,7 +272,6 @@ struct zckCtx {
     int has_streams;
     int has_optional_elems;
     int has_uncompressed_source;
-    int no_check_min_size;
 
     char *read_buf;
     size_t read_buf_size;

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -149,9 +149,8 @@ struct zckDL {
 /* Contains an index item pointing to a chunk */
 struct zckChunk {
     char *digest;
-    int digest_size;
     char *digest_uncompressed;
-    int digest_size_uncompressed;
+    int digest_size;
     int valid;
     size_t number;
     size_t start;

--- a/src/zck.c
+++ b/src/zck.c
@@ -230,8 +230,7 @@ int main (int argc, char *argv[]) {
     }
 
     if(arguments.uncompressed) {
-        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1) || 
-          (!zck_set_ioption(zck, ZCK_NO_MIN_CHUNKSIZE, 1))) {
+        if(!zck_set_ioption(zck, ZCK_UNCOMP_HEADER, 1)) {
             dprintf(STDERR_FILENO, "%s\n", zck_get_error(zck));
             exit(1);
         }


### PR DESCRIPTION
This PR has a number of cleanup commits, but the main thing it adds is a `--compressed-format=(zstd|none) argument` to `zck`