### PR TITLE
Some more cleanup, add a couple of accessors and a test utility for uncompressed hash

### DIFF
--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -264,6 +264,8 @@ ssize_t zck_get_chunk_number(zckChunk *idx)
 /* Get validity of current chunk - 1 = valid, 0 = missing, -1 = invalid */
 int zck_get_chunk_valid(zckChunk *idx)
     __attribute__ ((warn_unused_result));
+/* set validity of current chunk - 1 = valid, 0 = missing, -1 = invalid */
+bool zck_set_chunk_valid(zckChunk *idx, int valid);
 /* Get chunk digest */
 char *zck_get_chunk_digest(zckChunk *item)
     __attribute__ ((warn_unused_result));

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -280,7 +280,9 @@ ssize_t zck_get_chunk_comp_data(zckChunk *idx, char *dst, size_t dst_size)
 /* Find out if two chunk digests are the same */
 bool zck_compare_chunk_digest(zckChunk *a, zckChunk *b)
     __attribute__ ((warn_unused_result));
-
+/* Get associate src chunk if any */
+zckChunk *zck_get_src_chunk(zckChunk *idx)
+    __attribute__ ((warn_unused_result));
 
 /*******************************************************************
  * Advanced hash functions

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -86,7 +86,8 @@ ssize_t zck_write(zckCtx *zck, const char *src, const size_t src_size)
 /* Create a chunk boundary */
 ssize_t zck_end_chunk(zckCtx *zck)
     __attribute__ ((warn_unused_result));
-
+/* Create the database for uthash if not present (done automatically by read */
+bool zck_generate_hashdb(zckCtx *zck);
 
 /*******************************************************************
  * Common functions for finishing a zchunk file
@@ -174,7 +175,8 @@ int zck_failed_chunks(zckCtx *zck)
     __attribute__ ((warn_unused_result));
 /* Reset failed chunks to become missing */
 void zck_reset_failed_chunks(zckCtx *zck);
-
+/* Find chunks from a source */
+bool zck_find_matching_chunks(zckCtx *src, zckCtx *tgt);
 
 /*******************************************************************
  * The functions should be all you need to read and write a zchunk

--- a/include/zck.h.in
+++ b/include/zck.h.in
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdarg.h>
 #include <sys/types.h>
 
 typedef enum zck_hash {
@@ -129,6 +130,9 @@ const char *zck_get_error(zckCtx *zck);
 /* Clear error message
  * Returns 1 if message was cleared, 0 if error is fatal and can't be cleared */
 bool zck_clear_error(zckCtx *zck);
+/* Set a callback for logs instead to write into a fd */
+typedef void (*logcallback)(const char *function, zck_log_type lt, const char *format, va_list args);
+void zck_set_log_callback(logcallback function);
 
 /*******************************************************************
  * Miscellaneous utilities

--- a/src/lib/comp/comp.c
+++ b/src/lib/comp/comp.c
@@ -553,15 +553,11 @@ const char PUBLIC *zck_comp_name_from_type(int comp_type) {
 ssize_t PUBLIC zck_write(zckCtx *zck, const char *src, const size_t src_size) {
     VALIDATE_WRITE_INT(zck);
 
-    zck_log(ZCK_LOG_DDEBUG, "Starting up");
-
     if(src_size == 0)
         return 0;
 
     if(!zck->comp.started && !comp_init(zck))
         return -1;
-
-    zck_log(ZCK_LOG_DDEBUG, "Starting up");
 
     const char *loc = src;
     size_t loc_size = src_size;

--- a/src/lib/index/index_common.c
+++ b/src/lib/index/index_common.c
@@ -48,6 +48,7 @@ void index_clean(zckIndex *index) {
         return;
 
     HASH_CLEAR(hh, index->ht);
+    HASH_CLEAR(hhuncomp, index->htuncomp);
     if(index->first) {
         zckChunk *next;
         zckChunk *tmp=index->first;

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -183,6 +183,17 @@ zckChunk PUBLIC *zck_get_next_chunk(zckChunk *idx) {
     return idx->next;
 }
 
+zckChunk PUBLIC *zck_get_src_chunk(zckChunk *idx) {
+    if(idx && idx->zck) {
+        VALIDATE_PTR(idx->zck);
+        ALLOCD_PTR(idx->zck, idx);
+    } else {
+        ALLOCD_PTR(NULL, idx);
+    }
+
+    return idx->src;
+}
+
 ssize_t PUBLIC zck_get_chunk_start(zckChunk *idx) {
     if(idx && idx->zck) {
         VALIDATE_INT(idx->zck);

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -105,9 +105,9 @@ bool index_read(zckCtx *zck, char *data, size_t size, size_t max_length) {
                 return false;
             }
             memcpy(new->digest_uncompressed, data+length, zck->index.digest_size);
-            HASH_FIND(hh, zck->index.ht, new->digest, new->digest_size, tmp);
+            HASH_FIND(hhuncomp, zck->index.htuncomp, new->digest_uncompressed, new->digest_size, tmp);
             if(!tmp)
-               HASH_ADD_KEYPTR(hhuncomp, zck->index_uncomp.ht, new->digest_uncompressed, new->digest_size,
+               HASH_ADD_KEYPTR(hhuncomp, zck->index.htuncomp, new->digest_uncompressed, new->digest_size,
                                new);
             length += zck->index.digest_size;
 	}

--- a/src/lib/index/index_read.c
+++ b/src/lib/index/index_read.c
@@ -252,6 +252,22 @@ int PUBLIC zck_get_chunk_valid(zckChunk *idx) {
     return idx->valid;
 }
 
+bool PUBLIC zck_set_chunk_valid(zckChunk *idx, int valid) {
+    if (!idx)
+        return false;
+    switch (valid) {
+        case -1:
+        case 0:
+        case 1:
+            break;
+        default:
+            return false;
+    }
+    idx->valid = valid;
+
+    return true;
+}
+
 bool PUBLIC zck_compare_chunk_digest(zckChunk *a, zckChunk *b) {
     if(a && a->zck) {
         VALIDATE_BOOL(a->zck);

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -36,6 +36,8 @@
 static zck_log_type log_level = ZCK_LOG_ERROR;
 static int log_fd = STDERR_FILENO;
 
+static logcallback callback = NULL; 
+
 void PUBLIC zck_set_log_level(zck_log_type ll) {
     log_level = ll;
 }
@@ -44,14 +46,24 @@ void PUBLIC zck_set_log_fd(int fd) {
     log_fd = fd;
 }
 
+void PUBLIC zck_set_log_callback(logcallback function) {
+    if (!function)
+        return;
+    callback = function;
+}
+
 void zck_log_v(const char *function, zck_log_type lt, const char *format,
      va_list args) {
     if(lt < log_level || log_level == ZCK_LOG_ERROR)
         return;
 
-    dprintf(log_fd, "%s: ", function);
-    vdprintf(log_fd, format, args);
-    dprintf(log_fd, "\n");
+    if (callback) {
+        callback(function, lt, format, args);
+    } else {
+        dprintf(log_fd, "%s: ", function);
+        vdprintf(log_fd, format, args);
+        dprintf(log_fd, "\n");
+    }
 }
 
 void zck_log_wf(const char *function, zck_log_type lt, const char *format, ...) {

--- a/src/lib/zck_private.h
+++ b/src/lib/zck_private.h
@@ -173,6 +173,7 @@ struct zckIndex {
     zckChunk *last;
     zckChunk *current;
     zckChunk *ht;
+    zckChunk *htuncomp;
 };
 
 /* Contains a single range */
@@ -264,7 +265,6 @@ struct zckCtx {
     zckIndex index;
     zckChunk *work_index_item;
     zckHash work_index_hash;
-    zckIndex index_uncomp;
     zckChunk *work_index_item_uncomp;
     zckHash work_index_hash_uncomp;
     size_t stream;

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,6 +24,13 @@ read_single_comp_chunk = executable('read_single_comp_chunk',
                                     include_directories: incdir,
                                     dependencies: [zstd_dep, openssl_dep])
 shacheck = executable('shacheck', ['shacheck.c'] + util_sources, include_directories: incdir, dependencies: [zstd_dep, openssl_dep])
+zck_cmp_uncomp = executable(
+    'zck_cmp_uncomp',
+    ['zck_cmp_uncomp.c'],
+    include_directories: incdir,
+    link_with: zcklib,
+    install: false
+)
 file_path = join_paths(meson.source_root(), 'test/files')
 
 test(

--- a/test/zck_cmp_uncomp.c
+++ b/test/zck_cmp_uncomp.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2021 Stefano Babic <stefano.babic@babic.homelinux.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <argp.h>
+#include <zck.h>
+
+#define BUFSIZE 16384
+static char doc[] = "zck_gen_header - Compare a file with a zck and reports which chunks changed";
+
+static char args_doc[] = "<uncompressed file> <zck file>";
+
+static struct argp_option options[] = {
+    {"verbose",     'v', 0,        0,
+     "Increase verbosity (can be specified more than once for debugging)"},
+    {"show-chunks", 'c', 0,        0, "Show chunk information"},
+    {"quiet",       'q', 0,        0, "Only show errors"},
+    {"version",     'V', 0,        0, "Show program version"},
+    {"verify",      'f', 0,        0, "Verify full zchunk file"},
+    { 0 }
+};
+
+struct arguments {
+  char *args[2];
+  bool verify;
+  bool quiet;
+  bool show_chunks;
+  zck_log_type log_level;
+  bool exit;
+};
+
+static void version(void) {
+    exit(EXIT_SUCCESS);
+}
+
+static error_t parse_opt (int key, char *arg, struct argp_state *state) {
+    struct arguments *arguments = state->input;
+
+    if(arguments->exit)
+        return 0;
+
+    switch (key) {
+        case 'v':
+            arguments->log_level--;
+            if(arguments->log_level < ZCK_LOG_DDEBUG)
+                arguments->log_level = ZCK_LOG_DDEBUG;
+            break;
+        case 'V':
+            version();
+            arguments->exit = true;
+            break;
+
+        case ARGP_KEY_ARG:
+            if (state->arg_num >= 2) {
+                argp_usage (state);
+                return EINVAL;
+            }
+            arguments->args[state->arg_num] = arg;
+
+            break;
+
+        case ARGP_KEY_END:
+            if (state->arg_num < 1) {
+                argp_usage (state);
+                return EINVAL;
+            }
+            break;
+
+        default:
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+
+int main (int argc, char *argv[]) {
+    struct arguments arguments = {0};
+    arguments.log_level = ZCK_LOG_ERROR;
+
+    int retval = argp_parse (&argp, argc, argv, 0, 0, &arguments);
+    if(retval || arguments.exit)
+        exit(retval);
+
+    if (argc < 1) {
+       	dprintf(STDERR_FILENO, "Usage : %s filename", argv[0]);
+       	exit(1);
+    }
+
+    zck_set_log_level(arguments.log_level);
+    int dst_fd = open("/dev/null", O_TRUNC | O_WRONLY | O_CREAT, 0666);
+
+    zckCtx *zckSrc = zck_create();
+    zckCtx *zckDst = zck_create();
+    if(!zckSrc || !zckDst) {
+        dprintf(STDERR_FILENO, "%s", zck_get_error(NULL));
+        zck_clear_error(NULL);
+        exit(1);
+    }
+    if(!zck_init_write(zckSrc, dst_fd)) {
+        dprintf(STDERR_FILENO, "Unable to write %s ",
+                zck_get_error(zckSrc));
+        exit(1);
+    }
+   
+    int in_fd = open(arguments.args[0], O_RDONLY);
+    off_t in_size = 0;
+    if(in_fd < 0) {
+        dprintf(STDERR_FILENO, "Unable to open %s for reading",
+                arguments.args[0]);
+        perror("");
+        exit(1);
+    }
+
+    /*
+     * Read header in the zck file
+     */
+    int zck_fd = open(arguments.args[1], O_RDONLY);
+    if(zck_fd < 0) {
+        dprintf(STDERR_FILENO, "Unable to open %s for reading",
+                arguments.args[1]);
+        perror("");
+        exit(1);
+    }
+
+    if(!zck_init_read(zckDst, zck_fd)) {
+        dprintf(STDERR_FILENO, "Error reading zchunk header: %s",
+                zck_get_error(zckDst));
+        zck_free(&zckSrc);
+        zck_free(&zckDst);
+        exit(1);
+    }
+
+    in_size = lseek(in_fd, 0, SEEK_END);
+    if(in_size < 0) {
+        dprintf(STDERR_FILENO, "Unable to seek to end of input file");
+        exit(1);
+    }
+    if(lseek(in_fd, 0, SEEK_SET) < 0) {
+        perror("Unable to seek to beginning of input file");
+        exit(1);
+    }
+
+    if(!zck_set_ioption(zckSrc, ZCK_UNCOMP_HEADER, 1)) {
+        dprintf(STDERR_FILENO, "%s\n", zck_get_error(zckSrc));
+        exit(1);
+    }
+    if(!zck_set_ioption(zckSrc, ZCK_COMP_TYPE, ZCK_COMP_NONE))
+        exit(1);
+    if(!zck_set_ioption(zckSrc, ZCK_HASH_CHUNK_TYPE, ZCK_HASH_SHA256)) {
+        dprintf(STDERR_FILENO, "Unable to set hash type %s\n", zck_get_error(zckSrc));
+        exit(1);
+    }
+
+    char *buf = malloc(BUFSIZE);
+    if (!buf) {
+        dprintf(STDERR_FILENO, "Unable to allocate buffer\n");
+        exit(1);
+    }
+    ssize_t n;
+    while ((n = read(in_fd, buf, BUFSIZE)) > 0) {
+        if (zck_write(zckSrc, buf, n) < 0) {
+            dprintf(STDERR_FILENO, "zck_write failed: %s\n", zck_get_error(zckSrc));
+            exit(1);
+        }
+    }
+    /*
+     * Start comparison
+     */
+    dprintf(STDOUT_FILENO, "Compare original image with chunks in zck\n");
+    dprintf(STDOUT_FILENO, "-----------------------------------------\n");
+    
+    zck_generate_hashdb(zckSrc);
+    zck_find_matching_chunks(zckSrc, zckDst);
+
+    zckChunk *iter = zck_get_first_chunk(zckDst);
+    size_t todwl = 0;
+    size_t reuse = 0;
+    while (iter) {
+        dprintf(STDOUT_FILENO, "%12lu %s %s %12lu %12lu\n",
+                zck_get_chunk_number(iter),
+                zck_get_chunk_valid(iter) ? "SRC" : "DST",
+                zck_get_chunk_digest_uncompressed(iter),
+                zck_get_chunk_start(iter),
+                zck_get_chunk_size(iter));
+
+        if (!zck_get_chunk_valid(iter)) {
+                   todwl += zck_get_chunk_comp_size(iter);
+        } else {
+            reuse += zck_get_chunk_size(iter);
+
+        }
+        iter = zck_get_next_chunk(iter);
+    }
+
+    dprintf (STDOUT_FILENO, "\n\nTotal to be reused : %12lu\n", reuse);
+    dprintf (STDOUT_FILENO, "Total to be downloaded : %12lu\n", todwl);
+
+    close(in_fd);
+    close(zck_fd);
+    zck_free(&zckSrc);
+    zck_free(&zckDst);
+    close(dst_fd);
+}


### PR DESCRIPTION
This PR contains some  ore cleanup:
- drop redundant "Starting" log
- drop redundant index structure for uncompressed data (not used at all)
- generate a uthash for uncompressed data, too.

This adds, too:
- allow callback for logging
- add test utility to test the uncompressed hash. Utility reports with chunks are changed between an uncompressed (plain) file and a ZCK file.