### PR TITLE
add github action

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,0 +1,11 @@
+name: zchunk_test_env
+channels:
+- conda-forge
+dependencies:
+- libcurl
+- zstd
+- meson
+- c-compiler
+- ninja
+- pkg-config
+- sel(osx): argp-standalone

--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -8,4 +8,5 @@ dependencies:
 - c-compiler
 - ninja
 - pkg-config
+- openssl
 - sel(osx): argp-standalone

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    name: Compile and Run Tests
+    steps:
+      - uses: actions/checkout@v2
+      - name: install mamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: .github/environment.yml
+      - name: Compile zchunk
+        shell: bash -l {0}
+        run: |
+          meson builddir
+          cd builddir
+          ninja
+      - name: Run zchunk tests
+        shell: bash -l {0}
+        run: |
+          cd builddir
+          ninja test


### PR DESCRIPTION
Hi @jdieter this adds a github action to test Linux & macOS builds (successfully).
You can find a run here: https://github.com/wolfv/zchunk/actions/runs/1612528834

This runs on free machines provided by GitHub. 

Once you merge this, I would rebase my PR for Windows and start testing that, too.

Note that in this case I use `mamba` & `conda-forge` to obtain the dependencies. It's convenient because we have the same source of dependencies for Linux, macOS and Windows.
We can later also integrate an alternative action that runs against Fedora 35 in a docker container or similar.