### PR TITLE
pre-commit config & github linter CI

### DIFF
--- a/.github/lint_environment.yml
+++ b/.github/lint_environment.yml
@@ -1,0 +1,7 @@
+name: lint
+channels:
+  - conda-forge
+dependencies:
+  - pre-commit
+  - pip
+  # - clang-format ==X.X

--- a/.github/lint_environment.yml
+++ b/.github/lint_environment.yml
@@ -1,7 +1,0 @@
-name: lint
-channels:
-  - conda-forge
-dependencies:
-  - pre-commit
-  - pip
-  # - clang-format ==X.X

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,10 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: install mamba
-      uses: mamba-org/provision-with-micromamba@v11
+    - uses: actions/setup-python@v2
       with:
-        environment-file: .github/lint_environment.yml
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+    - name: Install pre-commit
+      shell: bash -l {0}
+      run: |
+        pip install pre-commit
     - name: Run all linters
       shell: bash -l {0}
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,23 @@
+name: Run Linters
+
+on:
+  push:
+   branches:
+     - main
+  pull_request:
+    branches:
+     - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install mamba
+      uses: mamba-org/provision-with-micromamba@v11
+      with:
+        environment-file: .github/lint_environment.yml
+    - name: Run all linters
+      shell: bash -l {0}
+      run: |
+        pre-commit run --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: end-of-file-fixer
+        exclude: ^(test/files|autotest/)


### PR DESCRIPTION
This adds a `.pre-commit-config.yml` config and a github actions based linter step. 

Currently it only checks for end of file newlines (and auto-corrects them when running locally with `pre-commit run --all`.

There are a couple other nice linter steps supported with `pre-commit`. A list of pre-provided hooks is here: https://github.com/pre-commit/pre-commit-hooks

One I find personally quite useful is `clang-format`. 
That could be configured like so:

```
-   repo: https://github.com/bmorcos/pre-commit-hooks-cpp
    rev: master
    hooks:
    -   id: clang-format
        args: [--style=file]
```

And would require an `.clang-format` in the root of the repo (e.g. https://github.com/mamba-org/mamba/blob/master/.clang-format). We'd need to figure out the proper values to match the current style of zchunk.