### PR TITLE
print only length characters

### DIFF
--- a/src/lib/zck.c
+++ b/src/lib/zck.c
@@ -278,8 +278,8 @@ bool ZCK_PUBLIC_API zck_set_soption(zckCtx *zck, zck_soption option, const char 
                                  chk_type.digest_size*2, length);
             return false;
         }
-        zck_log(ZCK_LOG_DEBUG, "Setting expected hash to (%s)%s",
-                zck_hash_name_from_type(zck->prep_hash_type), data);
+        zck_log(ZCK_LOG_DEBUG, "Setting expected hash to (%s)%.*s",
+                zck_hash_name_from_type(zck->prep_hash_type), length, data);
         zck->prep_digest = ascii_checksum_to_bin(zck, data, length);
         free(data);
         if(zck->prep_digest == NULL) {


### PR DESCRIPTION
I noticed that the debug log message was overrunning because we only allocate `length` bytes and no `\0` terminator.