### PR TITLE
do not assume /usr/bin/zstd

### DIFF
--- a/src/zck_gen_zdict.c
+++ b/src/zck_gen_zdict.c
@@ -306,7 +306,7 @@ int main (int argc, char *argv[]) {
 #else
     int pid = fork();
     if(pid == 0) {
-        execl("/usr/bin/zstd", "zstd", "--train", dir, "-r", "-o", out_name, NULL);
+        execl("zstd", "zstd", "--train", dir, "-r", "-o", out_name, NULL);
         LOG_ERROR("Unable to find /usr/bin/zstd\n");
         exit(1);
     }


### PR DESCRIPTION
I don't think my solution is appropriate. But ideally we'd either code a `which` function or figure out another way how to get the binary from `$PATH`.

In the "conda" case `zstd` is usually found in `$CONDA_PREFIX/bin/zstd` (which is also added to `$PATH`).