### PR TITLE
Turn off EOL handling for the *.zck test files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 
 test/files/* text eol=lf
+test/files/*.zck text=false eol=false


### PR DESCRIPTION
Hi,

What do you think about this trivial change that stops Git from modifying the (binary) *.zck test files at all? At least for me, with Git 2.35.1 on a Debian testing system, the attributes file was not enough to stop Git from converting CR/LF to LF in the compressed files, thus breaking things in various ways.

Thanks in advance, and keep up the great work!

G'luck,
Peter
