### PR TITLE
meson.build: fix cross-compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ endif
 
 # argp-standalone dependency (if required)
 if build_machine.system() == 'windows' or build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); return 0; }; void main() {}')
-    if fs.is_dir(join_paths([get_option('prefix'), 'include']))
+    if not meson.is_cross_build() and fs.is_dir(join_paths([get_option('prefix'), 'include']))
         inc += include_directories(join_paths([get_option('prefix'), 'include']))
     endif
     argplib = cc.find_library('argp', dirs : join_paths([get_option('prefix'), 'lib']))


### PR DESCRIPTION
Don't include paths on host when cross-compiling to avoid the following build failure raised since version 1.2.0 and https://github.com/zchunk/zchunk/commit/13ca71af959a771820f03cca870400e88f84e84a:

```
[1/181] Compiling C object src/lib/libzck.so.1.2.2.p/buzhash_buzhash.c.o
FAILED: src/lib/libzck.so.1.2.2.p/buzhash_buzhash.c.o
/home/giuliobenetti/autobuild/run/instance-1/output-1/host/bin/powerpc-linux-gcc -Isrc/lib/libzck.so.1.2.2.p -Isrc/lib -I../src/lib -Iinclude -I../include -I/usr/include -I/home/giuliobenetti/autobuild/run/instance-1/output-1/host/powerpc-buildroot-linux-uclibc/sysroot/usr/include -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu99 -O3 -Wunused-result -DZCHUNK_ZSTD -DZCHUNK_OPENSSL -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -Os -g0 -fPIC -fvisibility=hidden -MD -MQ src/lib/libzck.so.1.2.2.p/buzhash_buzhash.c.o -MF src/lib/libzck.so.1.2.2.p/buzhash_buzhash.c.o.d -o src/lib/libzck.so.1.2.2.p/buzhash_buzhash.c.o -c ../src/lib/buzhash/buzhash.c
powerpc-linux-gcc: ERROR: unsafe header/library path used in cross-compilation: '-I/usr/include'
```

Fixes:
 - http://autobuild.buildroot.org/results/45577db086d67dfb89970a7ad0783e9f1f832f06

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>