### PR TITLE
meson: fix argp-standalone wrap and find_library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,24 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/checkout@v2
-        with:
-          repository: wolfv/argp-standalone
-          path: argp-standalone
-
       - name: Install mamba
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: .github/environment.yml
-
-      - name: Compile argp-standalone
-        shell: cmd /C CALL {0}
-        run: |
-          CALL micromamba activate zchunk_test_env
-          cd argp-standalone
-          meson setup builddir
-          meson compile -C builddir --prefix=%CONDA_PREFIX%\Library
-          meson install -C builddir
 
       - name: Compile zchunk
         shell: cmd /C CALL {0}
@@ -75,25 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/checkout@v2
-        with:
-          repository: wolfv/argp-standalone
-          path: argp-standalone
-
       - uses: actions/setup-python@v1
         with:
           python-version: '3.x'
 
       - name: Install meson and ninja
         run: pip install meson ninja
-
-      - name: Compile argp-standalone
-        shell: cmd /C CALL {0}
-        run: |
-          cd argp-standalone
-          meson setup builddir
-          meson compile -C builddir
-          meson install -C builddir
 
       - name: Compile zchunk
         shell: cmd /C CALL {0}

--- a/meson.build
+++ b/meson.build
@@ -58,10 +58,10 @@ endif
 
 # argp-standalone dependency (if required)
 if build_machine.system() == 'windows' or build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); return 0; }; void main() {}')
-    if fs.is_dir(join_paths([get_option('prefix'), 'include']))
-        inc += include_directories(join_paths([get_option('prefix'), 'include']))
+    argplib = cc.find_library('argp', has_headers : ['argp.h'], required: false)
+    if not argplib.found()
+        argplib = dependency('argp-standalone')
     endif
-    argplib = cc.find_library('argp', dirs : join_paths([get_option('prefix'), 'lib']))
 else
     argplib = dependency('', required : false)
 endif

--- a/subprojects/argp-standalone.wrap
+++ b/subprojects/argp-standalone.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory = argp-standalone-1.4.1
+url = https://github.com/argp-standalone/argp-standalone.git
+revision = 21855f34ec9997c37e1a08cd69497336513a5800
+
+[provide]
+dependency_names = argp-standalone


### PR DESCRIPTION
Currently using my own fork of [`argp-standalone`](https://github.com/argp-standalone/argp-standalone) with a few fixes I submitted upstream [here](https://github.com/argp-standalone/argp-standalone/pull/7) but should fix the wrap build on windows.