### PR TITLE
zck: declare write_data as static

### DIFF
--- a/src/zck.c
+++ b/src/zck.c
@@ -159,7 +159,7 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state) {
 
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
-void write_data(zckCtx *zck, char *data, ssize_t in_size) {
+static void write_data(zckCtx *zck, char *data, ssize_t in_size) {
     if(zck_write(zck, data, in_size) < 0) {
         LOG_ERROR("%s", zck_get_error(zck));
         exit(1);


### PR DESCRIPTION
This needs to be declared static to avoid a symbol conflict:
```c
io.c:(.text+0xe8): multiple definition of `write_data'; src/zck.p/zck.c.o:zck.c:(.text+0x1f4): first defined here
```

Fixes:
 - http://autobuild.buildroot.net/results/225/22590a7038a40da3700d56c1f82f7dc74225702a