### PR TITLE
argp-standalone.wrap: update to version 1.5.0

### DIFF
--- a/subprojects/argp-standalone.wrap
+++ b/subprojects/argp-standalone.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
-directory = argp-standalone-1.4.1
+directory = argp-standalone-1.5.0
 url = https://github.com/argp-standalone/argp-standalone.git
-revision = 21855f34ec9997c37e1a08cd69497336513a5800
+revision = 1.5.0
 
 [provide]
 dependency_names = argp-standalone


### PR DESCRIPTION
Now that `1.5.0` is tagged we can use that instead of a commit hash.