### PR TITLE
Clarify what the primary benefit of zchunk is

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 zchunk is a compressed file format that splits the file into independent chunks.
 This allows you to only download changed chunks when downloading a new version
-of the file, and also makes zchunk files efficient over rsync.
+of the file.  Files can hosted on any web server that supports HTTP ranged
+requests, with no special software required to serve the files (though to
+download only the changed chunks, your client must be zchunk-aware).
 
 zchunk files are protected with strong checksums to verify that the file you
 downloaded is, in fact, the file you wanted.


### PR DESCRIPTION
zstd now offers rsync-friendly output, so mentioning that zchunk files are efficient over rsync misses the primary benefit zchunk has, namely that zchunk files can be downloaded efficiently from normal web servers that support range requests (which is basically all of them, except for some rather strange proxies).

Fixes #86 

Signed-off-by: Jonathan Dieter <jdieter@gmail.com>