### PR TITLE
Dont let clang optimize away a meson check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ if host_machine.system() == 'windows'
 endif
 
 # argp-standalone dependency (if required)
-if build_machine.system() == 'windows' or build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nstatic error_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); return 0; }; void main() {}')
+if build_machine.system() == 'windows' or build_machine.system() == 'darwin' or build_machine.system() == 'freebsd' or not cc.links('#include <argp.h>\nerror_t parse_opt (int key, char *arg, struct argp_state *state) { argp_usage(state); return 0; }; void main() {}')
     argplib = cc.find_library('argp', has_headers : ['argp.h'], required: false)
     if not argplib.found()
         argplib = dependency('argp-standalone')


### PR DESCRIPTION
The test fails with clang erroneously

Upstream-Status: Pending