### PR TITLE
Missing header file on AIX

### DIFF
--- a/src/unzck.c
+++ b/src/unzck.c
@@ -40,7 +40,9 @@
 #include <libgen.h>
 #endif
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 
 #include "util_common.h"

--- a/src/zck.c
+++ b/src/zck.c
@@ -39,7 +39,9 @@
 #include <libgen.h>
 #endif
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 
 #include "util_common.h"

--- a/src/zck_delta_size.c
+++ b/src/zck_delta_size.c
@@ -33,7 +33,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 
 #include "util_common.h"

--- a/src/zck_dl.c
+++ b/src/zck_dl.c
@@ -39,7 +39,9 @@
 #endif
 #include <unistd.h>
 #include <errno.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 #include <curl/curl.h>
 

--- a/src/zck_gen_zdict.c
+++ b/src/zck_gen_zdict.c
@@ -44,7 +44,9 @@
 #endif
 #include <dirent.h>
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 
 #if defined(stdout)

--- a/src/zck_read_header.c
+++ b/src/zck_read_header.c
@@ -34,7 +34,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 
 #include "util_common.h"

--- a/test/zck_cmp_uncomp.c
+++ b/test/zck_cmp_uncomp.c
@@ -39,7 +39,9 @@
 #include <libgen.h>
 #endif
 #include <unistd.h>
+#ifndef _AIX
 #include <argp.h>
+#endif
 #include <zck.h>
 #include "util.h"
 


### PR DESCRIPTION
argp header file is not present on AIX. Hence building of zchunk on AIX fails. So I put a conditional dependency to include the argp header file.